### PR TITLE
fix: validate timeout, retries, group ID, and metric regex

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -215,6 +216,20 @@ func ParseRetentionDuration(s string) (time.Duration, error) {
 func validate(cfg *Config) error {
 	if cfg.PollIntervalSeconds <= 0 {
 		return fmt.Errorf("pollIntervalSeconds must be > 0, got %d", cfg.PollIntervalSeconds)
+	}
+	if cfg.KafkaClientTimeoutSeconds <= 0 {
+		return fmt.Errorf("kafkaClientTimeoutSeconds must be > 0, got %d", cfg.KafkaClientTimeoutSeconds)
+	}
+	if cfg.KafkaRetries < 0 {
+		return fmt.Errorf("kafkaRetries must be >= 0, got %d", cfg.KafkaRetries)
+	}
+	if cfg.ClientGroupID == "" {
+		return fmt.Errorf("clientGroupId must not be empty")
+	}
+	for i, pattern := range cfg.MetricWhitelist {
+		if _, err := regexp.Compile(pattern); err != nil {
+			return fmt.Errorf("metricWhitelist[%d] is not a valid regex %q: %w", i, pattern, err)
+		}
 	}
 	if cfg.Sinks.Prometheus.Enabled {
 		if cfg.Sinks.Prometheus.Port <= 0 || cfg.Sinks.Prometheus.Port > 65535 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -116,6 +116,26 @@ func TestLoad_ValidationErrors(t *testing.T) {
 			errMsg: "lookup.memory.size must be >= 2",
 		},
 		{
+			name:   "invalid timeout",
+			yaml:   "kafkaClientTimeoutSeconds: 0",
+			errMsg: "kafkaClientTimeoutSeconds must be > 0",
+		},
+		{
+			name:   "negative retries",
+			yaml:   "kafkaRetries: -1",
+			errMsg: "kafkaRetries must be >= 0",
+		},
+		{
+			name:   "empty client group ID",
+			yaml:   "clientGroupId: \"\"",
+			errMsg: "clientGroupId must not be empty",
+		},
+		{
+			name:   "invalid metric whitelist regex",
+			yaml:   "metricWhitelist:\n  - \"[invalid\"",
+			errMsg: "metricWhitelist[0] is not a valid regex",
+		},
+		{
 			name:   "cluster missing name",
 			yaml:   "clusters:\n  - bootstrapBrokers: localhost:9092",
 			errMsg: "cluster[0].name is required",


### PR DESCRIPTION
## Summary
- Reject `kafkaClientTimeoutSeconds <= 0`
- Reject `kafkaRetries < 0`
- Reject empty `clientGroupId`
- Validate `metricWhitelist` patterns are valid regex

## Test plan
- [x] 4 new test cases in `config_test.go`
- [x] All unit tests pass

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)