### PR TITLE
fix: block on watcher event send instead of dropping

### DIFF
--- a/internal/watcher/strimzi.go
+++ b/internal/watcher/strimzi.go
@@ -110,12 +110,12 @@ func (w *StrimziWatcher) watch(ctx context.Context) error {
 			if !ok {
 				return fmt.Errorf("watch channel closed")
 			}
-			w.handleEvent(event)
+			w.handleEvent(ctx, event)
 		}
 	}
 }
 
-func (w *StrimziWatcher) handleEvent(event watch.Event) {
+func (w *StrimziWatcher) handleEvent(ctx context.Context, event watch.Event) {
 	obj, ok := event.Object.(*unstructured.Unstructured)
 	if !ok {
 		w.logger.Warn("unexpected object type in watch event")
@@ -142,8 +142,7 @@ func (w *StrimziWatcher) handleEvent(event watch.Event) {
 
 	select {
 	case w.events <- ce:
-	default:
-		w.logger.Warn("watcher event channel full, dropping event", "cluster", cluster.Name, "type", event.Type)
+	case <-ctx.Done():
 	}
 }
 

--- a/internal/watcher/strimzi_test.go
+++ b/internal/watcher/strimzi_test.go
@@ -1,6 +1,7 @@
 package watcher
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 	"time"
@@ -337,7 +338,7 @@ func TestStrimziWatcher_HandleEvent_InvalidObject(t *testing.T) {
 	}
 
 	// Send a watch.Event with a metav1.Status instead of an Unstructured.
-	w.handleEvent(watch.Event{
+	w.handleEvent(context.Background(), watch.Event{
 		Type:   watch.Added,
 		Object: &metav1.Status{Message: "test"},
 	})


### PR DESCRIPTION
## Summary
- `handleEvent()` now blocks on channel send instead of dropping events when buffer is full
- Send respects context cancellation for clean shutdown

## Test plan
- [x] Watcher tests pass
- [x] All unit tests pass

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)