### PR TITLE
fix: handle nil current snapshot in removal functions

### DIFF
--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -661,6 +661,20 @@ func TestSnapshot_RemovedTPs_NilPrev(t *testing.T) {
 	assert.Nil(t, RemovedTopicPartitions(nil, current))
 }
 
+func TestSnapshot_RemovedGTPs_NilCurrent(t *testing.T) {
+	prev := &OffsetsSnapshot{GroupOffsets: domain.GroupOffsets{
+		{Group: "g1", Topic: "t1", Partition: 0}: {Offset: 10},
+	}}
+	assert.Nil(t, RemovedGroupTopicPartitions(prev, nil))
+}
+
+func TestSnapshot_RemovedTPs_NilCurrent(t *testing.T) {
+	prev := &OffsetsSnapshot{LatestOffsets: domain.PartitionOffsets{
+		{Topic: "t1", Partition: 0}: {Offset: 100},
+	}}
+	assert.Nil(t, RemovedTopicPartitions(prev, nil))
+}
+
 // --- Negative lag clamping --------------------------------------------------
 
 func TestCollector_NegativeLagClampedToZero(t *testing.T) {

--- a/internal/collector/snapshot.go
+++ b/internal/collector/snapshot.go
@@ -38,6 +38,9 @@ func RemovedGroupTopicPartitions(prev, current *OffsetsSnapshot) []domain.GroupT
 	if prev == nil {
 		return nil
 	}
+	if current == nil {
+		return nil
+	}
 	currentSet := make(map[domain.GroupTopicPartition]bool, len(current.GroupOffsets))
 	for gtp := range current.GroupOffsets {
 		currentSet[gtp] = true
@@ -55,6 +58,9 @@ func RemovedGroupTopicPartitions(prev, current *OffsetsSnapshot) []domain.GroupT
 // RemovedTopicPartitions returns TPs that were in prev but not in current.
 func RemovedTopicPartitions(prev, current *OffsetsSnapshot) []domain.TopicPartition {
 	if prev == nil {
+		return nil
+	}
+	if current == nil {
 		return nil
 	}
 	currentSet := make(map[domain.TopicPartition]bool, len(current.LatestOffsets))


### PR DESCRIPTION
## Summary
- Add nil check for `current` parameter in `RemovedGroupTopicPartitions()` and `RemovedTopicPartitions()`
- Prevents panic when current snapshot is nil (e.g., first poll failure)

## Test plan
- [x] 2 new test cases for nil current snapshot
- [x] All unit tests pass

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)