### PR TITLE
fix: drop oldest metrics when graphite buffer overflows

### DIFF
--- a/internal/sink/graphite.go
+++ b/internal/sink/graphite.go
@@ -60,12 +60,22 @@ func (s *GraphiteSink) Report(_ context.Context, m metrics.MetricValue) {
 	line := fmt.Sprintf("%s %v %d\n", path, m.Value, now)
 
 	s.mu.Lock()
-	if s.maxBufSize > 0 && s.buf.Len()+len(line) > s.maxBufSize {
-		s.logger.Warn("graphite buffer full, dropping metric", "metric", m.Definition.Name, "bufSize", s.buf.Len())
-		s.mu.Unlock()
-		return
-	}
 	s.buf.WriteString(line)
+	if s.maxBufSize > 0 && s.buf.Len() > s.maxBufSize {
+		overflow := s.buf.Len() - s.maxBufSize
+		data := s.buf.Bytes()
+		// Advance past the overflow region to the next newline so we drop
+		// whole lines (complete metrics) rather than leaving a partial line.
+		idx := bytes.IndexByte(data[overflow:], '\n')
+		if idx >= 0 {
+			drop := overflow + idx + 1
+			remaining := make([]byte, len(data)-drop)
+			copy(remaining, data[drop:])
+			s.buf.Reset()
+			s.buf.Write(remaining)
+		}
+		s.logger.Warn("graphite buffer full, dropped oldest metrics", "metric", m.Definition.Name, "bufSize", s.buf.Len())
+	}
 	s.mu.Unlock()
 }
 

--- a/internal/sink/graphite_test.go
+++ b/internal/sink/graphite_test.go
@@ -171,3 +171,31 @@ func TestGraphiteSink_Stop_Noop(t *testing.T) {
 	s := &GraphiteSink{}
 	s.Stop() // Should not panic.
 }
+
+func TestGraphiteSink_BufferOverflow_DropsOldest(t *testing.T) {
+	filter, _ := NewMetricFilter([]string{".*"})
+	s := NewGraphiteSink("127.0.0.1", 1, "test", false, filter, slog.Default())
+	s.maxBufSize = 100 // Very small buffer.
+
+	ctx := context.Background()
+	// Fill the buffer with metrics.
+	for i := 0; i < 20; i++ {
+		s.Report(ctx, metrics.MetricValue{
+			Definition: metrics.PartitionLatestOffset,
+			Labels:     map[string]string{"cluster_name": "cluster", "topic": "topic", "partition": "0"},
+			Value:      float64(i),
+		})
+	}
+
+	s.mu.Lock()
+	bufLen := s.buf.Len()
+	bufContent := s.buf.String()
+	s.mu.Unlock()
+
+	// Buffer should be capped near maxBufSize.
+	assert.LessOrEqual(t, bufLen, s.maxBufSize)
+	// Should contain the latest metrics, not the oldest.
+	assert.Contains(t, bufContent, "19")
+	// Should NOT contain the earliest metric.
+	assert.NotContains(t, bufContent, " 0 ")
+}


### PR DESCRIPTION
## Summary
- Fixes #8
- When the Graphite buffer exceeds `maxBufSize`, drop the oldest metrics (lines) instead of rejecting the newest
- Uses `bytes.IndexByte` to find clean newline boundaries so we never leave partial lines
- Adds test for buffer overflow behavior

## Test plan
- [x] `go test ./internal/sink/ -run TestGraphiteSink` passes
- [ ] Verify in integration that metrics flow correctly under high volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)