### PR TITLE
feat: make Prometheus cardinality limit configurable

### DIFF
--- a/cmd/kafka-lag-exporter/main.go
+++ b/cmd/kafka-lag-exporter/main.go
@@ -65,7 +65,7 @@ func main() {
 	var promSink *sink.PrometheusSink
 
 	if cfg.Sinks.Prometheus.Enabled {
-		promSink, err = sink.NewPrometheusSink(cfg.Sinks.Prometheus.Port, cfg.Sinks.Prometheus.BindAddress, filter, logger.With("sink", "prometheus"))
+		promSink, err = sink.NewPrometheusSink(cfg.Sinks.Prometheus.Port, cfg.Sinks.Prometheus.BindAddress, cfg.Sinks.Prometheus.MaxTimeSeries, filter, logger.With("sink", "prometheus"))
 		if err != nil {
 			logger.Error("failed to create prometheus sink", "error", err)
 			os.Exit(1)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -159,7 +159,7 @@ func TestKafkaEndToEnd(t *testing.T) {
 	rec := &recordingSink{}
 	port := 19190 + int(time.Now().UnixNano()%100)
 	filter, _ := sink.NewMetricFilter([]string{".*"})
-	promSink, err := sink.NewPrometheusSink(port, "", filter, slog.Default())
+	promSink, err := sink.NewPrometheusSink(port, "", 100000, filter, slog.Default())
 	require.NoError(t, err)
 	defer promSink.Stop()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,9 +87,10 @@ type SinksConfig struct {
 
 // PrometheusSinkConfig configures the Prometheus sink.
 type PrometheusSinkConfig struct {
-	Enabled     bool   `mapstructure:"enabled"`
-	Port        int    `mapstructure:"port"`
-	BindAddress string `mapstructure:"bindAddress"`
+	Enabled       bool   `mapstructure:"enabled"`
+	Port          int    `mapstructure:"port"`
+	BindAddress   string `mapstructure:"bindAddress"`
+	MaxTimeSeries int    `mapstructure:"maxTimeSeries"`
 }
 
 // GraphiteSinkConfig configures the Graphite sink.
@@ -164,6 +165,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("sinks.prometheus.enabled", true)
 	v.SetDefault("sinks.prometheus.port", 8000)
 	v.SetDefault("sinks.prometheus.bindAddress", "")
+	v.SetDefault("sinks.prometheus.maxTimeSeries", 100000)
 	v.SetDefault("sinks.graphite.enabled", false)
 	v.SetDefault("sinks.graphite.host", "localhost")
 	v.SetDefault("sinks.graphite.port", 2003)

--- a/internal/sink/prometheus.go
+++ b/internal/sink/prometheus.go
@@ -62,7 +62,7 @@ type PrometheusSink struct {
 
 // NewPrometheusSink creates and starts a Prometheus HTTP endpoint on the given port.
 // If bindAddress is empty, it binds to all interfaces (0.0.0.0).
-func NewPrometheusSink(port int, bindAddress string, filter *MetricFilter, logger *slog.Logger) (*PrometheusSink, error) {
+func NewPrometheusSink(port int, bindAddress string, maxTimeSeries int, filter *MetricFilter, logger *slog.Logger) (*PrometheusSink, error) {
 	reg := prometheus.NewRegistry()
 
 	gauges := make(map[string]*prometheus.GaugeVec)
@@ -120,7 +120,7 @@ func NewPrometheusSink(port int, bindAddress string, filter *MetricFilter, logge
 		gauges:        gauges,
 		filter:        filter,
 		logger:        logger,
-		maxTimeSeries: 100000,
+		maxTimeSeries: maxTimeSeries,
 		pollsTotal:    pollsTotal,
 		pollErrors:    pollErrors,
 		pollDuration:  pollDuration,

--- a/internal/sink/prometheus_test.go
+++ b/internal/sink/prometheus_test.go
@@ -30,7 +30,7 @@ func TestPrometheusSink_ReportAndScrape(t *testing.T) {
 	filter, err := NewMetricFilter([]string{".*"})
 	require.NoError(t, err)
 
-	sink, err := NewPrometheusSink(port, "", filter, logger)
+	sink, err := NewPrometheusSink(port, "", 100000, filter, logger)
 	require.NoError(t, err)
 	defer sink.Stop()
 
@@ -68,7 +68,7 @@ func TestPrometheusSink_Remove(t *testing.T) {
 	filter, err := NewMetricFilter([]string{".*"})
 	require.NoError(t, err)
 
-	sink, err := NewPrometheusSink(port, "", filter, logger)
+	sink, err := NewPrometheusSink(port, "", 100000, filter, logger)
 	require.NoError(t, err)
 	defer sink.Stop()
 
@@ -104,7 +104,7 @@ func TestPrometheusSink_Filter(t *testing.T) {
 	filter, err := NewMetricFilter([]string{"kafka_consumergroup.*"})
 	require.NoError(t, err)
 
-	sink, err := NewPrometheusSink(port, "", filter, logger)
+	sink, err := NewPrometheusSink(port, "", 100000, filter, logger)
 	require.NoError(t, err)
 	defer sink.Stop()
 
@@ -139,7 +139,7 @@ func TestPrometheusSink_Filter(t *testing.T) {
 func TestPrometheusSink_NaN_Ignored(t *testing.T) {
 	port := getFreePort()
 	filter, _ := NewMetricFilter([]string{".*"})
-	sink, err := NewPrometheusSink(port, "", filter, slog.Default())
+	sink, err := NewPrometheusSink(port, "", 100000, filter, slog.Default())
 	require.NoError(t, err)
 	defer sink.Stop()
 	time.Sleep(100 * time.Millisecond)
@@ -160,7 +160,7 @@ func TestPrometheusSink_NaN_Ignored(t *testing.T) {
 func TestPrometheusSink_Inf_Ignored(t *testing.T) {
 	port := getFreePort()
 	filter, _ := NewMetricFilter([]string{".*"})
-	sink, err := NewPrometheusSink(port, "", filter, slog.Default())
+	sink, err := NewPrometheusSink(port, "", 100000, filter, slog.Default())
 	require.NoError(t, err)
 	defer sink.Stop()
 	time.Sleep(100 * time.Millisecond)
@@ -187,7 +187,7 @@ func TestPrometheusSink_Inf_Ignored(t *testing.T) {
 func TestPrometheusSink_HealthEndpoint(t *testing.T) {
 	port := getFreePort()
 	filter, _ := NewMetricFilter([]string{".*"})
-	sink, err := NewPrometheusSink(port, "", filter, slog.Default())
+	sink, err := NewPrometheusSink(port, "", 100000, filter, slog.Default())
 	require.NoError(t, err)
 	defer sink.Stop()
 	time.Sleep(100 * time.Millisecond)
@@ -200,7 +200,7 @@ func TestPrometheusSink_HealthEndpoint(t *testing.T) {
 
 func TestPrometheusSink_NilFilter(t *testing.T) {
 	port := getFreePort()
-	sink, err := NewPrometheusSink(port, "", nil, slog.Default())
+	sink, err := NewPrometheusSink(port, "", 100000, nil, slog.Default())
 	require.NoError(t, err)
 	defer sink.Stop()
 	time.Sleep(100 * time.Millisecond)
@@ -222,7 +222,7 @@ func TestPrometheusSink_NilFilter(t *testing.T) {
 func TestPrometheusSink_UnknownMetric(t *testing.T) {
 	port := getFreePort()
 	filter, _ := NewMetricFilter([]string{".*"})
-	sink, err := NewPrometheusSink(port, "", filter, slog.Default())
+	sink, err := NewPrometheusSink(port, "", 100000, filter, slog.Default())
 	require.NoError(t, err)
 	defer sink.Stop()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Fixes #6
- Add `sinks.prometheus.maxTimeSeries` config option (default 100000)
- Users with large clusters can raise this limit; users wanting tighter control can lower it
- Wired through config → main → PrometheusSink constructor

## Test plan
- [x] `go test ./internal/sink/ -run TestPrometheusSink` passes
- [x] `go test ./internal/config/` passes
- [x] `go build ./...` succeeds
- [ ] Verify in config.yaml that `sinks.prometheus.maxTimeSeries: 50000` takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)