### PR TITLE
ci: publish helm chart as OCI artifact to GHCR on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,3 +60,47 @@ jobs:
             VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  helm:
+    name: Package & Push Helm Chart
+    needs: docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+
+      - name: Derive chart version from tag
+        id: version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Pin default image tag in values.yaml
+        run: |
+          yq -i '.image.tag = "${{ steps.version.outputs.version }}"' \
+            charts/kafka-lag-exporter/values.yaml
+
+      - name: Lint chart
+        run: helm lint charts/kafka-lag-exporter
+
+      - name: Package chart
+        run: |
+          helm package charts/kafka-lag-exporter \
+            --version "${{ steps.version.outputs.version }}" \
+            --app-version "${{ steps.version.outputs.version }}"
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io \
+              -u "${{ github.actor }}" --password-stdin
+
+      - name: Push chart to GHCR
+        run: |
+          helm push \
+            "kafka-lag-exporter-${{ steps.version.outputs.version }}.tgz" \
+            "oci://ghcr.io/${{ github.repository_owner }}/charts"

--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ docker run -p 8000:8000 -v $(pwd)/config.yaml:/etc/kafka-lag-exporter/config.yam
 
 ### Install with Helm
 
+The chart is published as an OCI artifact to GHCR. No `helm repo add` is needed — Helm 3.8+ can install directly from the registry:
+
+```bash
+helm install kafka-lag-exporter \
+  oci://ghcr.io/carlgra/charts/kafka-lag-exporter \
+  --version 1.0.1 \
+  --namespace kafka-lag-exporter \
+  --create-namespace
+```
+
+Pin to a specific release with `--version`; omit it to install the latest. Browse all versions at [github.com/carlgra/kafka-lag-exporter/pkgs/container/charts%2Fkafka-lag-exporter](https://github.com/carlgra/kafka-lag-exporter/pkgs/container/charts%2Fkafka-lag-exporter).
+
+To install from a local checkout (e.g. while developing the chart):
+
 ```bash
 helm install kafka-lag-exporter ./charts/kafka-lag-exporter \
   --namespace kafka-lag-exporter \


### PR DESCRIPTION
## Summary
- Adds a `helm` job to `release.yml` that packages the chart on tag push and pushes it to `oci://ghcr.io/carlgra/charts/kafka-lag-exporter`
- Pins the chart `version`, `appVersion`, and default `image.tag` in `values.yaml` to the release tag so the chart and image stay in lockstep
- Updates README with the OCI install command (no `helm repo add` needed on Helm 3.8+)

Addresses the hosted-chart ask in #29.

## Post-merge checklist
- [ ] Cut a new release tag (e.g. `v1.0.2`) — the helm job only runs on tag push, so existing releases won't retroactively publish a chart
- [ ] After the first push creates the GHCR package, flip it from private → public: Packages → `charts/kafka-lag-exporter` → Package settings → Change visibility → Public. Without this, anonymous `helm pull` gets 401
- [ ] Reply on #29 once the package is public and installable

## Test plan
- [x] `make check` passes locally (fmt, vet, lint, tests)
- [x] `helm lint charts/kafka-lag-exporter` passes
- [ ] On the next release tag, confirm the `helm` job runs green and the chart appears under the repo's GHCR packages
- [ ] After flipping visibility to public, verify `helm install kafka-lag-exporter oci://ghcr.io/carlgra/charts/kafka-lag-exporter --version <ver>` works from a clean env

🤖 Generated with [Claude Code](https://claude.com/claude-code)