### PR TITLE
ci: replace compromised Trivy scanner with govulncheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.25.9"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.25.9"
 
       - name: Run tests
         run: go test -race -count=1 -coverprofile=coverage.out ./internal/...
@@ -69,7 +69,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.25.9"
 
       - name: Build binary
         run: make build
@@ -88,34 +88,34 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.25.9"
 
       - name: Run integration tests
         run: make test-integration
 
   security:
+    # Scans Go dependencies for known CVEs using govulncheck (official Go team
+    # tool, pulls from the Go module proxy, call-graph aware so it only flags
+    # CVEs your code actually reaches).
+    #
+    # Previously used Trivy via `aquasec/trivy:latest`. Removed after the
+    # March 2026 Trivy supply chain compromise (CVE-2026-33634, CISA KEV):
+    # malicious releases exfiltrated CI secrets. Do not re-introduce without
+    # pinning to a known-good version/digest from a trusted registry.
     name: Security Scan
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - uses: actions/checkout@v4
 
-      - name: Trivy filesystem scan (Go deps + IaC)
-        run: |
-          docker run --rm -v "$PWD:/src" -w /src aquasec/trivy:latest fs \
-            --severity CRITICAL,HIGH --exit-code 1 .
-
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.25.9"
 
-      - name: Build Docker image
-        run: docker build -t kafka-lag-exporter:ci .
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
-      - name: Trivy image scan
-        run: |
-          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image \
-            --severity CRITICAL,HIGH --exit-code 1 kafka-lag-exporter:ci
+      - name: Run govulncheck
+        run: govulncheck ./...
 
   helm-lint:
     name: Helm Lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.25.9-alpine AS builder
 RUN apk add --no-cache git ca-certificates
 WORKDIR /build
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary
- Removes `aquasec/trivy:latest` Docker Hub pulls from the `Security Scan` CI job
- Replaces with `govulncheck` pinned to `v1.1.4` (official Go team tool, call-graph aware, pulled from the Go module proxy)
- Pins Go toolchain to `1.25.9` in CI and Dockerfile to pick up stdlib CVE fixes govulncheck surfaced
- Keeps job id and display name as `Security Scan` so existing branch protection required-check context still matches — **no admin-level changes needed**

## Why now
The Trivy ecosystem was compromised in March 2026 ([CVE-2026-33634](https://www.cvedetails.com/cve/CVE-2026-33634/), [CISA KEV](https://www.cisa.gov/news-events/alerts/2026/03/26/cisa-adds-one-known-exploited-vulnerability-catalog)). Malicious `v0.69.4`–`v0.69.6` releases on Docker Hub exfiltrated CI secrets (AWS/GCP/Azure creds, SSH keys, K8s tokens, Git credentials). Unpinned `:latest` pulls on every CI run are exactly the attack vector. The reason the scan started failing recently is Aqua pulled the poisoned images from Docker Hub.

### Exposure assessment for this repo
- No CI runs executed between **Mar 19** and **late Mar 2026** (compromise window). Last pre-compromise run: Mar 9. Next run: today, April 13 — which failed on image pull, so no malicious code executed.
- No `tpcp-docs` repo in the `carlgra` org (the IoC for successful fallback exfiltration).
- **Not exposed**, but we should not re-enable unpinned Trivy pulls.

## Why govulncheck over re-pinning Trivy
- Official Go team tool, distributed through the Go module proxy (different trust chain from the compromised one)
- Call-graph aware — only flags CVEs your code actually reaches, far lower false-positive rate for a Go static binary
- No OS-package surface to scan here anyway (scratch-ish build), so Trivy's OS scanner adds little value
- Found 4 real stdlib CVEs on first run (all fixed by bumping Go to 1.25.9, done in this PR)

## Test plan
- [x] `make check` passes locally (fmt, vet, lint, tests)
- [x] `govulncheck ./...` runs locally — found exactly the CVEs fixed by the Go bump
- [ ] CI `Security Scan` passes on this PR after Go 1.25.9 is picked up
- [ ] After merge, #30 rebases onto master and its `Security Scan` also goes green

## Merge ordering
This PR first. Then #30 rebases and becomes mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)