### PR TITLE
fix(strimzi): scope watch to configured namespace when strimziWatchNamespace set

### DIFF
--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -134,3 +134,6 @@ data:
         {{- end }}
     watchers:
       strimzi: {{ .Values.watchers.strimzi }}
+      {{- if .Values.watchers.strimziWatchNamespace }}
+      strimziWatchNamespace: {{ .Values.watchers.strimziWatchNamespace | quote }}
+      {{- end }}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,11 @@ type ClusterConfig struct {
 // WatcherConfig configures cluster watchers.
 type WatcherConfig struct {
 	Strimzi bool `mapstructure:"strimzi"`
+	// StrimziWatchNamespace, when set, restricts the Strimzi watcher to a
+	// single namespace. Empty string means watch cluster-wide (requires
+	// ClusterRole). Must match the namespace of the Role/RoleBinding created
+	// by the Helm chart when running namespace-scoped.
+	StrimziWatchNamespace string `mapstructure:"strimziWatchNamespace"`
 }
 
 // LookupConfig configures the offset lookup table.

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -49,7 +49,7 @@ func New(cfg *config.Config, sinks []sink.Sink, lookupFactory func() lookup.Look
 		sinks:          sinks,
 		lookupFactory:  lookupFactory,
 		clientFactory:  defaultClientFactory,
-		watcherFactory: defaultWatcherFactory,
+		watcherFactory: defaultWatcherFactoryFor(cfg),
 		collectors:     make(map[string]collectorEntry),
 		logger:         logger,
 	}
@@ -80,8 +80,14 @@ func defaultClientFactory(clusterCfg config.ClusterConfig, globalCfg *config.Con
 	return kafka.NewFranzClient(clusterCfg, globalCfg, logger)
 }
 
-func defaultWatcherFactory(logger *slog.Logger) (watcher.Watcher, error) {
-	return watcher.NewStrimziWatcher(logger)
+// defaultWatcherFactoryFor returns a WatcherFactory that creates a
+// StrimziWatcher pinned to the namespace configured in cfg. The closure keeps
+// the WatcherFactory signature (logger-only) stable so tests overriding it via
+// WithWatcherFactory don't need to thread config through.
+func defaultWatcherFactoryFor(cfg *config.Config) WatcherFactory {
+	return func(logger *slog.Logger) (watcher.Watcher, error) {
+		return watcher.NewStrimziWatcher(cfg.Watchers.StrimziWatchNamespace, logger)
+	}
 }
 
 // Start launches collectors for all configured clusters and starts watchers.

--- a/internal/watcher/strimzi.go
+++ b/internal/watcher/strimzi.go
@@ -25,15 +25,21 @@ var kafkaGVR = schema.GroupVersionResource{
 
 // StrimziWatcher watches Strimzi Kafka CRDs and emits ClusterEvents.
 type StrimziWatcher struct {
-	client dynamic.Interface
-	events chan ClusterEvent
-	cancel context.CancelFunc
-	logger *slog.Logger
+	client    dynamic.Interface
+	namespace string
+	events    chan ClusterEvent
+	cancel    context.CancelFunc
+	logger    *slog.Logger
 }
 
 // NewStrimziWatcher creates a new Strimzi CRD watcher.
 // It requires in-cluster Kubernetes configuration.
-func NewStrimziWatcher(logger *slog.Logger) (*StrimziWatcher, error) {
+//
+// If namespace is empty, the watch is cluster-scoped and the ServiceAccount
+// must have a ClusterRole granting watch on kafkas.kafka.strimzi.io. If
+// namespace is non-empty, the watch is restricted to that namespace and a
+// namespace-scoped Role/RoleBinding is sufficient.
+func NewStrimziWatcher(namespace string, logger *slog.Logger) (*StrimziWatcher, error) {
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, fmt.Errorf("getting in-cluster config: %w", err)
@@ -46,10 +52,11 @@ func NewStrimziWatcher(logger *slog.Logger) (*StrimziWatcher, error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	w := &StrimziWatcher{
-		client: client,
-		events: make(chan ClusterEvent, 16),
-		cancel: cancel,
-		logger: logger,
+		client:    client,
+		namespace: namespace,
+		events:    make(chan ClusterEvent, 16),
+		cancel:    cancel,
+		logger:    logger,
 	}
 
 	go w.run(ctx)
@@ -57,13 +64,14 @@ func NewStrimziWatcher(logger *slog.Logger) (*StrimziWatcher, error) {
 }
 
 // NewStrimziWatcherFromClient creates a watcher with a provided dynamic client (for testing).
-func NewStrimziWatcherFromClient(client dynamic.Interface, logger *slog.Logger) *StrimziWatcher {
+func NewStrimziWatcherFromClient(client dynamic.Interface, namespace string, logger *slog.Logger) *StrimziWatcher {
 	ctx, cancel := context.WithCancel(context.Background())
 	w := &StrimziWatcher{
-		client: client,
-		events: make(chan ClusterEvent, 16),
-		cancel: cancel,
-		logger: logger,
+		client:    client,
+		namespace: namespace,
+		events:    make(chan ClusterEvent, 16),
+		cancel:    cancel,
+		logger:    logger,
 	}
 	go w.run(ctx)
 	return w
@@ -96,7 +104,16 @@ func (w *StrimziWatcher) run(ctx context.Context) {
 }
 
 func (w *StrimziWatcher) watch(ctx context.Context) error {
-	watcher, err := w.client.Resource(kafkaGVR).Namespace("").Watch(ctx, metav1.ListOptions{})
+	// Empty namespace = cluster-scoped watch (requires ClusterRole).
+	// Non-empty = namespace-scoped watch (Role in that namespace suffices).
+	resource := w.client.Resource(kafkaGVR)
+	var watcher watch.Interface
+	var err error
+	if w.namespace == "" {
+		watcher, err = resource.Watch(ctx, metav1.ListOptions{})
+	} else {
+		watcher, err = resource.Namespace(w.namespace).Watch(ctx, metav1.ListOptions{})
+	}
 	if err != nil {
 		return fmt.Errorf("starting watch: %w", err)
 	}

--- a/internal/watcher/strimzi_test.go
+++ b/internal/watcher/strimzi_test.go
@@ -229,6 +229,11 @@ func TestExtractClusterConfig_AddressesPrioritizedOverBootstrapServers(t *testin
 
 func newFakeWatcher(t *testing.T) (*StrimziWatcher, *watch.FakeWatcher) {
 	t.Helper()
+	return newFakeWatcherWithNamespace(t, "")
+}
+
+func newFakeWatcherWithNamespace(t *testing.T, namespace string) (*StrimziWatcher, *watch.FakeWatcher) {
+	t.Helper()
 
 	scheme := runtime.NewScheme()
 	fakeClient := fakedynamic.NewSimpleDynamicClient(scheme)
@@ -236,7 +241,7 @@ func newFakeWatcher(t *testing.T) (*StrimziWatcher, *watch.FakeWatcher) {
 	fw := watch.NewFake()
 	fakeClient.PrependWatchReactor("kafkas", k8stesting.DefaultWatchReactor(fw, nil))
 
-	w := NewStrimziWatcherFromClient(fakeClient, slog.Default())
+	w := NewStrimziWatcherFromClient(fakeClient, namespace, slog.Default())
 	return w, fw
 }
 
@@ -349,6 +354,78 @@ func TestStrimziWatcher_HandleEvent_InvalidObject(t *testing.T) {
 		t.Fatalf("should not have received event, got: %+v", event)
 	default:
 	}
+}
+
+// --- Namespace scope tests --------------------------------------------------
+
+// recordingClient wraps a fake dynamic client to capture the namespace passed
+// to the Resource().Namespace().Watch() call. We record by spying on the
+// reactor invocation, since fakedynamic doesn't expose the namespace cleanly
+// through its action recorder for the cluster-scope vs namespace-scope
+// distinction.
+func newRecordingFakeWatcher(t *testing.T, namespace string) (*StrimziWatcher, *watch.FakeWatcher, func() string) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	fakeClient := fakedynamic.NewSimpleDynamicClient(scheme)
+
+	fw := watch.NewFake()
+	var observedNS string
+	fakeClient.PrependWatchReactor("kafkas", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		observedNS = action.GetNamespace()
+		return true, fw, nil
+	})
+
+	w := NewStrimziWatcherFromClient(fakeClient, namespace, slog.Default())
+	return w, fw, func() string { return observedNS }
+}
+
+func TestStrimziWatcher_Watch_ClusterScope(t *testing.T) {
+	w, fw, observed := newRecordingFakeWatcher(t, "")
+	defer w.Stop()
+
+	// Trigger an event so we know the watch has been started.
+	kafkaObj := &unstructured.Unstructured{}
+	kafkaObj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "kafka.strimzi.io",
+		Version: "v1beta2",
+		Kind:    "Kafka",
+	})
+	kafkaObj.SetName("k")
+	kafkaObj.SetNamespace("any-ns")
+	fw.Add(kafkaObj)
+
+	select {
+	case <-w.Events():
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+
+	assert.Equal(t, "", observed(), "cluster-scope watch should pass empty namespace")
+}
+
+func TestStrimziWatcher_Watch_NamespaceScope(t *testing.T) {
+	const ns = "nightly-backend-kafka"
+	w, fw, observed := newRecordingFakeWatcher(t, ns)
+	defer w.Stop()
+
+	kafkaObj := &unstructured.Unstructured{}
+	kafkaObj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "kafka.strimzi.io",
+		Version: "v1beta2",
+		Kind:    "Kafka",
+	})
+	kafkaObj.SetName("k")
+	kafkaObj.SetNamespace(ns)
+	fw.Add(kafkaObj)
+
+	select {
+	case <-w.Events():
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+
+	assert.Equal(t, ns, observed(), "namespace-scope watch should pass configured namespace")
 }
 
 func TestStrimziWatcher_Stop(t *testing.T) {


### PR DESCRIPTION
## Summary
Reported by @edgarkz on #29 — Strimzi watcher with `strimziWatchNamespace` set fails with:

```
kafkas.kafka.strimzi.io is forbidden: User
"system:serviceaccount:<ns>:kafka-lag-exporter-serviceaccount"
cannot watch resource "kafkas" in API group "kafka.strimzi.io"
at the cluster scope
```

## Root cause
The Helm chart correctly switches from `ClusterRole`/`ClusterRoleBinding` to `Role`/`RoleBinding` when `watchers.strimziWatchNamespace` is set. But `internal/watcher/strimzi.go` was unconditionally doing:

```go
client.Resource(kafkaGVR).Namespace("").Watch(ctx, ...)
```

`Namespace("")` = cluster-scoped watch, which needs `ClusterRole`. The chart and the Go code disagreed. Without `strimziWatchNamespace` it worked because the cluster-scoped `ClusterRole` was created; with it, only a namespaced `Role` existed and the cluster watch was denied.

## Fix
Plumb the namespace end-to-end:

- `values.yaml` → `ConfigMap` (new `strimziWatchNamespace` key under `watchers:`)
- `config.WatcherConfig.StrimziWatchNamespace` (new field)
- `watcher.NewStrimziWatcher(namespace, logger)` accepts the namespace
- `StrimziWatcher.watch()` uses `.Namespace(ns).Watch(...)` when set, `.Watch(...)` (cluster scope) when empty

`WatcherFactory` signature is unchanged so tests overriding via `WithWatcherFactory` don't need updates — the default factory is now a closure over `cfg`.

## Test plan
- [x] `make check` passes (fmt, vet, lint, `go test -race -count=1 ./internal/... ./cmd/...`)
- [x] New watcher tests spy on the watch action and assert the correct namespace is passed in both cluster- and namespace-scoped modes
- [x] `helm template` with `watchers.strimziWatchNamespace=nightly-backend-kafka` renders `Role`+`RoleBinding` and a ConfigMap with the namespace
- [x] `helm template` without it still renders `ClusterRole`+`ClusterRoleBinding` (backward compat)
- [ ] @edgarkz to confirm fix in their cluster after v1.0.3 releases

## Related
- #29 reported by @edgarkz
- Two other issues from the same reporter (#32 listener resolution, #33 TLS client config) being investigated separately — independent code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)