### PR TITLE
fix(strimzi): resolve bootstrap address from listener name and bootstrapServers field

### DIFF
--- a/internal/watcher/strimzi.go
+++ b/internal/watcher/strimzi.go
@@ -157,36 +157,13 @@ func extractClusterConfig(obj *unstructured.Unstructured) (config.ClusterConfig,
 	if found {
 		listeners, found, _ := unstructured.NestedSlice(status, "listeners")
 		if found {
-			for _, l := range listeners {
-				listener, ok := l.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				ltype, _ := listener["type"].(string)
-				if ltype == "plain" || ltype == "tls" {
-					if addrs, ok := listener["addresses"].([]interface{}); ok && len(addrs) > 0 {
-						addr, ok := addrs[0].(map[string]interface{})
-						if ok {
-							host, _ := addr["host"].(string)
-							port, _ := addr["port"].(float64)
-							if host != "" && port > 0 {
-								bootstrapServers = fmt.Sprintf("%s:%d", host, int(port))
-								break
-							}
-						}
-					}
-					if bs, ok := listener["bootstrapServers"].(string); ok && bs != "" {
-						bootstrapServers = bs
-						break
-					}
-				}
-			}
+			bootstrapServers = pickListenerBootstrap(listeners)
 		}
 	}
 
 	// Fall back to conventional service name.
 	if bootstrapServers == "" {
-		bootstrapServers = fmt.Sprintf("%s-kafka-bootstrap.%s.svc:9092", name, namespace)
+		bootstrapServers = fmt.Sprintf("%s-kafka-bootstrap.%s.svc.cluster.local:9092", name, namespace)
 	}
 
 	clusterName := name
@@ -201,4 +178,83 @@ func extractClusterConfig(obj *unstructured.Unstructured) (config.ClusterConfig,
 		Name:             clusterName,
 		BootstrapBrokers: bootstrapServers,
 	}, nil
+}
+
+// pickListenerBootstrap selects the best in-cluster listener from the Strimzi
+// status.listeners slice and returns its bootstrap address.
+//
+// In modern Strimzi v1beta2 the listener `name` field carries values like
+// "plain"/"tls" while `type` identifies the Kubernetes exposure mechanism
+// ("internal", "route", "loadbalancer", "nodeport", "ingress", "cluster-ip").
+// Older Strimzi versions used `type` for "plain"/"tls" directly. We prefer
+// matching by `name` and fall back to `type` for backward compatibility.
+//
+// Only listeners with an empty `type` (legacy) or `type == "internal"` are
+// considered, since the exporter runs in-cluster and should not attempt to
+// reach external listener addresses.
+//
+// Within the matched listener, `bootstrapServers` is preferred over
+// `addresses[0]`: the former is the authoritative Strimzi-advertised bootstrap
+// string, while the latter may contain a single address that is not suitable
+// for bootstrap connections.
+func pickListenerBootstrap(listeners []interface{}) string {
+	// Priority: name=="plain", name=="tls", type=="plain" (legacy), type=="tls" (legacy).
+	type candidate struct {
+		priority int
+		listener map[string]interface{}
+	}
+	best := candidate{priority: 0}
+
+	for _, l := range listeners {
+		listener, ok := l.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		lname, _ := listener["name"].(string)
+		ltype, _ := listener["type"].(string)
+
+		// Skip external exposure types — exporter runs in-cluster.
+		// Allowed types: empty (legacy), "internal" (modern v1beta2), or the
+		// legacy values "plain"/"tls" which some older Strimzi versions used
+		// in the type field.
+		if ltype != "" && ltype != "internal" && ltype != "plain" && ltype != "tls" {
+			continue
+		}
+
+		prio := 0
+		switch {
+		case lname == "plain":
+			prio = 4
+		case lname == "tls":
+			prio = 3
+		case lname == "" && ltype == "plain":
+			prio = 2
+		case lname == "" && ltype == "tls":
+			prio = 1
+		default:
+			continue
+		}
+
+		if prio > best.priority {
+			best = candidate{priority: prio, listener: listener}
+		}
+	}
+
+	if best.listener == nil {
+		return ""
+	}
+
+	if bs, ok := best.listener["bootstrapServers"].(string); ok && bs != "" {
+		return bs
+	}
+	if addrs, ok := best.listener["addresses"].([]interface{}); ok && len(addrs) > 0 {
+		if addr, ok := addrs[0].(map[string]interface{}); ok {
+			host, _ := addr["host"].(string)
+			port, _ := addr["port"].(float64)
+			if host != "" && port > 0 {
+				return fmt.Sprintf("%s:%d", host, int(port))
+			}
+		}
+	}
+	return ""
 }

--- a/internal/watcher/strimzi_test.go
+++ b/internal/watcher/strimzi_test.go
@@ -85,7 +85,7 @@ func TestExtractClusterConfig_Fallback(t *testing.T) {
 	cluster, err := extractClusterConfig(obj)
 	require.NoError(t, err)
 	assert.Equal(t, "kafka-ns/my-kafka", cluster.Name)
-	assert.Equal(t, "my-kafka-kafka-bootstrap.kafka-ns.svc:9092", cluster.BootstrapBrokers)
+	assert.Equal(t, "my-kafka-kafka-bootstrap.kafka-ns.svc.cluster.local:9092", cluster.BootstrapBrokers)
 }
 
 func TestExtractClusterConfig_NoNamespace(t *testing.T) {
@@ -100,7 +100,7 @@ func TestExtractClusterConfig_NoNamespace(t *testing.T) {
 	cluster, err := extractClusterConfig(obj)
 	require.NoError(t, err)
 	assert.Equal(t, "my-kafka", cluster.Name) // No namespace prefix.
-	assert.Equal(t, "my-kafka-kafka-bootstrap..svc:9092", cluster.BootstrapBrokers)
+	assert.Equal(t, "my-kafka-kafka-bootstrap..svc.cluster.local:9092", cluster.BootstrapBrokers)
 }
 
 func TestExtractClusterConfig_TLSListener(t *testing.T) {
@@ -192,10 +192,10 @@ func TestExtractClusterConfig_EmptyListeners(t *testing.T) {
 	cluster, err := extractClusterConfig(obj)
 	require.NoError(t, err)
 	// Falls back to service name.
-	assert.Equal(t, "kafka-kafka-bootstrap.ns.svc:9092", cluster.BootstrapBrokers)
+	assert.Equal(t, "kafka-kafka-bootstrap.ns.svc.cluster.local:9092", cluster.BootstrapBrokers)
 }
 
-func TestExtractClusterConfig_AddressesPrioritizedOverBootstrapServers(t *testing.T) {
+func TestExtractClusterConfig_BootstrapServersPrioritizedOverAddresses(t *testing.T) {
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{
@@ -221,8 +221,124 @@ func TestExtractClusterConfig_AddressesPrioritizedOverBootstrapServers(t *testin
 
 	cluster, err := extractClusterConfig(obj)
 	require.NoError(t, err)
-	// addresses are checked first.
-	assert.Equal(t, "addr-host:9092", cluster.BootstrapBrokers)
+	// bootstrapServers is authoritative and wins over addresses[0].
+	assert.Equal(t, "bs-host:9092", cluster.BootstrapBrokers)
+}
+
+// --- modern Strimzi v1beta2 schema tests -----------------------------------
+
+func TestExtractClusterConfig_ModernSchema_InternalPlain(t *testing.T) {
+	// Modern Strimzi: `name` carries "plain"/"tls", `type` carries the
+	// exposure mechanism ("internal", "route", etc).
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "my-cluster",
+				"namespace": "kafka",
+			},
+			"status": map[string]interface{}{
+				"listeners": []interface{}{
+					map[string]interface{}{
+						"name":             "plain",
+						"type":             "internal",
+						"bootstrapServers": "my-cluster-kafka-bootstrap:9092",
+					},
+				},
+			},
+		},
+	}
+
+	cluster, err := extractClusterConfig(obj)
+	require.NoError(t, err)
+	assert.Equal(t, "kafka/my-cluster", cluster.Name)
+	assert.Equal(t, "my-cluster-kafka-bootstrap:9092", cluster.BootstrapBrokers)
+}
+
+func TestExtractClusterConfig_ModernSchema_InternalTLSOnly(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "my-cluster",
+				"namespace": "kafka",
+			},
+			"status": map[string]interface{}{
+				"listeners": []interface{}{
+					map[string]interface{}{
+						"name":             "tls",
+						"type":             "internal",
+						"bootstrapServers": "my-cluster-kafka-bootstrap:9093",
+					},
+				},
+			},
+		},
+	}
+
+	cluster, err := extractClusterConfig(obj)
+	require.NoError(t, err)
+	assert.Equal(t, "my-cluster-kafka-bootstrap:9093", cluster.BootstrapBrokers)
+}
+
+func TestExtractClusterConfig_ModernSchema_MixedInternalAndExternal(t *testing.T) {
+	// A cluster with both an internal plain listener and an external
+	// load-balancer listener must pick the internal one — the exporter
+	// runs in-cluster and the LB address is unreachable or undesirable.
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "my-cluster",
+				"namespace": "kafka",
+			},
+			"status": map[string]interface{}{
+				"listeners": []interface{}{
+					map[string]interface{}{
+						"name": "external",
+						"type": "loadbalancer",
+						"addresses": []interface{}{
+							map[string]interface{}{
+								"host": "203.0.113.10",
+								"port": float64(9094),
+							},
+						},
+						"bootstrapServers": "203.0.113.10:9094",
+					},
+					map[string]interface{}{
+						"name":             "plain",
+						"type":             "internal",
+						"bootstrapServers": "my-cluster-kafka-bootstrap:9092",
+					},
+				},
+			},
+		},
+	}
+
+	cluster, err := extractClusterConfig(obj)
+	require.NoError(t, err)
+	assert.Equal(t, "my-cluster-kafka-bootstrap:9092", cluster.BootstrapBrokers)
+}
+
+func TestExtractClusterConfig_LegacySchema_TypeOnly(t *testing.T) {
+	// Older Strimzi versions exposed listeners with `type` holding "plain"/"tls"
+	// and no `name` field. Ensure backward compatibility.
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "legacy-kafka",
+				"namespace": "ns",
+			},
+			"status": map[string]interface{}{
+				"listeners": []interface{}{
+					map[string]interface{}{
+						"type":             "plain",
+						"bootstrapServers": "legacy-broker:9092",
+					},
+				},
+			},
+		},
+	}
+
+	cluster, err := extractClusterConfig(obj)
+	require.NoError(t, err)
+	assert.Equal(t, "legacy-broker:9092", cluster.BootstrapBrokers)
 }
 
 // --- handleEvent tests using fake k8s watcher ------------------------------


### PR DESCRIPTION
## Summary

Fixes the Strimzi autodiscovery path in `internal/watcher/strimzi.go` so that offset collection against modern Strimzi v1beta2 clusters does not time out on an unreachable bootstrap address.

In modern Strimzi v1beta2, `status.listeners[].type` holds the exposure mechanism (`internal`, `loadbalancer`, `route`, `nodeport`, `ingress`, `cluster-ip`) and the listener **name** (`plain`/`tls`) is what the previous code was filtering on under `type`. As a result, modern clusters never matched the filter and fell through to the service-name fallback — which additionally used the short `.svc` suffix that not every kube-dns configuration resolves.

Reported by @edgarkz on #32 — leaving the issue open until the reporter confirms the fix resolves their setup.

PR #34 (the namespace-scope fix) is independent of this change and remains open.

## Changes

Three semantic changes in `extractClusterConfig`:

- **Match listeners by `name` first, `type` second (backward compat).** Prefer `name == "plain"`, then `name == "tls"`, then (legacy) `type == "plain"`, then (legacy) `type == "tls"`. Only consider listeners whose `type` is empty, `"internal"`, or legacy `"plain"`/`"tls"` — external exposures are skipped because the exporter runs in-cluster.
- **Prefer `bootstrapServers` over `addresses[0]`.** `bootstrapServers` is the authoritative Strimzi-advertised bootstrap string; `addresses[0]` is only a single address and is now the fallback.
- **Service-name fallback uses `.svc.cluster.local`.** `<name>-kafka-bootstrap.<ns>.svc.cluster.local:9092` is more robust across kube-dns configurations than the previous `.svc` form.

## Test plan

- [x] `make check` passes locally (gofmt, vet, golangci-lint, race tests)
- [x] New test: modern schema with `{name:"plain",type:"internal"}` picks the internal listener
- [x] New test: modern schema TLS-only `{name:"tls",type:"internal"}` picks TLS when no plain listener is present
- [x] New test: mixed `type:"internal"` + `type:"loadbalancer"` — internal wins, external is skipped
- [x] New test: legacy `{type:"plain"}` with no `name` field still works (backward compat)
- [x] New test: `bootstrapServers` wins over `addresses[0]` when both are set
- [x] Existing tests updated: fallback service name tests now expect `.svc.cluster.local`; the address-vs-bootstrapServers priority test renamed to reflect the new policy
- [ ] Reporter (@edgarkz) confirms offset collection succeeds against their modern Strimzi cluster

Generated with Claude Code