### PR TITLE
fix(kafka): resolve Dialer/TLS collision and add PEM keystore support

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,27 @@ Defined under `clusters[]` in the config file.
 | `topicAllowlist` | `[]` | No | Regex patterns for topics to monitor |
 | `topicDenylist` | `[]` | No | Regex patterns for topics to exclude |
 | `labels` | `{}` | No | Custom labels added to all metrics for this cluster |
-| `consumerProperties` | `{}` | No | Additional Kafka consumer properties (e.g., `security.protocol: SSL`) |
-| `adminClientProperties` | `{}` | No | Additional Kafka admin client properties |
+| `consumerProperties` | `{}` | No | Additional Kafka consumer properties (e.g., `security.protocol: SSL`). See [TLS / mTLS properties](#tls--mtls-properties). |
+| `adminClientProperties` | `{}` | No | Additional Kafka admin client properties. Merged with `consumerProperties`, so identical TLS/SASL config only needs to be declared once. |
 
 > **Backward Compatibility**: The deprecated field names `groupWhitelist`, `groupBlacklist`, `topicWhitelist`, `topicBlacklist`, and `metricWhitelist` are still supported. The new names take precedence if both are set.
+
+#### TLS / mTLS properties
+
+Set any of the following under `consumerProperties` (they are also merged into the admin client, so you do not need to repeat them under `adminClientProperties`):
+
+| Property | Description |
+|---|---|
+| `security.protocol` | `SSL` or `SASL_SSL` to enable TLS. Any value containing `SSL` triggers TLS. |
+| `ssl.truststore.location` | Path to a PEM-encoded CA bundle used to verify the broker. |
+| `ssl.truststore.type` | Accepted but informational — only `PEM` files are supported. |
+| `ssl.keystore.certificate.chain` | Path to the client certificate chain (PEM). Matches Kafka's property name when `ssl.keystore.type: PEM`. |
+| `ssl.keystore.key` | Path to the client private key (PEM). Pairs with `ssl.keystore.certificate.chain`. |
+| `ssl.keystore.location` | Legacy alias for the client certificate chain (PEM). |
+| `ssl.key.location` | Legacy alias for the client private key (PEM). |
+| `ssl.keystore.type` | Accepted but informational — only `PEM` files are supported. |
+
+If both the PEM-style (`ssl.keystore.certificate.chain` + `ssl.keystore.key`) and legacy (`ssl.keystore.location` + `ssl.key.location`) client-certificate properties are set, the PEM-style properties win and a warning is logged. JKS/PKCS#12 keystores are not supported — convert them to PEM first.
 
 ### Redis Configuration
 

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -21,10 +21,17 @@ clusters: {}
 #    # topicBlacklist: []
 #    # groupWhitelist: []
 #    # groupBlacklist: []
+#    # consumerProperties and adminClientProperties are merged before being
+#    # passed to the Kafka client, so identical TLS/SASL config only needs to
+#    # be declared once (either block is fine). See README.md for the full
+#    # list of supported ssl.* property names.
 #    consumerProperties:
 #      security.protocol: SSL
-#    adminClientProperties:
-#      security.protocol: SSL
+#      ssl.truststore.location: /etc/kafka-certs/ca.pem
+#      # PEM-style client cert (matches Kafka's ssl.keystore.type: PEM):
+#      ssl.keystore.certificate.chain: /etc/kafka-certs/client.pem
+#      ssl.keystore.key: /etc/kafka-certs/client.key
+#    adminClientProperties: {}
 #    labels:
 #      location: ny
 #      zone: "us-east"

--- a/internal/kafka/client.go
+++ b/internal/kafka/client.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"log/slog"
-	"net"
 	"os"
 	"strings"
 	"time"
@@ -47,11 +46,14 @@ func NewFranzClient(clusterCfg config.ClusterConfig, globalCfg *config.Config, l
 	brokers := strings.Split(clusterCfg.BootstrapBrokers, ",")
 	timeout := globalCfg.KafkaClientTimeout()
 
+	// Use kgo.DialTimeout rather than kgo.Dialer so it composes with
+	// kgo.DialTLSConfig below — franz-go rejects setting both Dialer and
+	// DialTLSConfig simultaneously.
 	opts := []kgo.Opt{
 		kgo.SeedBrokers(brokers...),
 		kgo.ConnIdleTimeout(timeout),
 		kgo.RequestTimeoutOverhead(timeout),
-		kgo.Dialer((&net.Dialer{Timeout: timeout}).DialContext),
+		kgo.DialTimeout(timeout),
 	}
 
 	// Merge consumer and admin client properties (they share the same connection in franz-go).
@@ -131,9 +133,36 @@ func buildTLSConfig(props map[string]string, logger *slog.Logger) (*tls.Config, 
 		logger.Debug("loaded CA certificate", "file", caFile)
 	}
 
-	// Load client certificate and key if provided.
-	certFile := props["ssl.keystore.location"]
-	keyFile := props["ssl.key.location"]
+	// Load client certificate and key if provided. Two sets of property names
+	// are accepted:
+	//   - PEM-style (matches Kafka's ssl.keystore.type=PEM and the original
+	//     Scala kafka-lag-exporter): ssl.keystore.certificate.chain +
+	//     ssl.keystore.key.
+	//   - Legacy convenience keys used by this exporter: ssl.keystore.location
+	//     (PEM cert chain) + ssl.key.location (PEM private key).
+	// If both are set, the PEM-style keys win and a warning is logged.
+	pemCertFile := props["ssl.keystore.certificate.chain"]
+	pemKeyFile := props["ssl.keystore.key"]
+	legacyCertFile := props["ssl.keystore.location"]
+	legacyKeyFile := props["ssl.key.location"]
+
+	var certFile, keyFile string
+	switch {
+	case pemCertFile != "" && pemKeyFile != "":
+		certFile, keyFile = pemCertFile, pemKeyFile
+		if legacyCertFile != "" || legacyKeyFile != "" {
+			logger.Warn(
+				"both PEM (ssl.keystore.certificate.chain/ssl.keystore.key) "+
+					"and legacy (ssl.keystore.location/ssl.key.location) client "+
+					"cert properties are set; using the PEM-style properties",
+				"pem_cert", pemCertFile,
+				"pem_key", pemKeyFile,
+			)
+		}
+	case legacyCertFile != "" && legacyKeyFile != "":
+		certFile, keyFile = legacyCertFile, legacyKeyFile
+	}
+
 	if certFile != "" && keyFile != "" {
 		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 		if err != nil {
@@ -142,6 +171,13 @@ func buildTLSConfig(props map[string]string, logger *slog.Logger) (*tls.Config, 
 		tlsCfg.Certificates = []tls.Certificate{cert}
 		logger.Debug("loaded client certificate", "cert", certFile, "key", keyFile)
 	}
+
+	// ssl.keystore.type / ssl.truststore.type of PEM are accepted silently —
+	// this exporter only supports PEM-format files regardless, so the value is
+	// informational. Unknown values are ignored for forward compatibility with
+	// Kafka's property namespace.
+	_ = props["ssl.keystore.type"]
+	_ = props["ssl.truststore.type"]
 
 	return tlsCfg, nil
 }

--- a/internal/kafka/client_test.go
+++ b/internal/kafka/client_test.go
@@ -1,12 +1,21 @@
 package kafka
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"io"
 	"log/slog"
+	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/seglo/kafka-lag-exporter/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -194,6 +203,171 @@ func TestClientMetrics_OnBrokerRead_Error(t *testing.T) {
 	m := &ClientMetrics{}
 	m.OnBrokerRead(kgo.BrokerMetadata{}, 0, 0, 0, 0, assert.AnError)
 	assert.Equal(t, int64(1), m.ReadErrors())
+}
+
+// --- TLS constructor tests --------------------------------------------------
+//
+// These are regression tests for a bug where NewFranzClient always appended
+// kgo.Dialer(...) to the options slice and additionally appended
+// kgo.DialTLSConfig(...) when security.protocol was SSL. franz-go rejects that
+// combination at NewClient time with "cannot set both Dialer and
+// DialTLSConfig", so any SSL-enabled cluster failed at startup.
+//
+// We cover three flavours of SSL config so the table of property-name variants
+// is exercised:
+//   - CA trust only (no client cert)
+//   - CA trust + PEM-style keystore (ssl.keystore.certificate.chain / ssl.keystore.key)
+//   - CA trust + legacy keystore (ssl.keystore.location / ssl.key.location)
+//
+// NewFranzClient does not open a network connection — kgo.NewClient is lazy —
+// so the constructor returning nil error is sufficient to prove the option set
+// validates.
+
+// tlsFixture writes a self-signed CA-ish cert + key to a t.TempDir() and
+// returns (caFile, certFile, keyFile). The same cert is used as both the CA
+// and the leaf, which is fine since we never actually establish a TLS
+// connection in these tests — we only care that the files parse.
+func tlsFixture(t *testing.T) (caFile, certFile, keyFile string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "kafka-lag-exporter-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	caFile = filepath.Join(dir, "ca.pem")
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	require.NoError(t, os.WriteFile(caFile, certPEM, 0600))
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0600))
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	require.NoError(t, os.WriteFile(keyFile, keyPEM, 0600))
+
+	return caFile, certFile, keyFile
+}
+
+func newFranzClientForTest(t *testing.T, props map[string]string) (*FranzClient, error) {
+	t.Helper()
+	clusterCfg := config.ClusterConfig{
+		Name:               "test",
+		BootstrapBrokers:   "127.0.0.1:9092",
+		ConsumerProperties: props,
+	}
+	globalCfg := &config.Config{KafkaClientTimeoutSeconds: 10}
+	return NewFranzClient(clusterCfg, globalCfg, noopLogger())
+}
+
+func TestNewFranzClient_SSL_TruststoreOnly(t *testing.T) {
+	caFile, _, _ := tlsFixture(t)
+	c, err := newFranzClientForTest(t, map[string]string{
+		"security.protocol":       "SSL",
+		"ssl.truststore.location": caFile,
+	})
+	require.NoError(t, err, "SSL-only config must not collide Dialer + DialTLSConfig")
+	require.NotNil(t, c)
+	t.Cleanup(c.Close)
+}
+
+func TestNewFranzClient_SSL_PEMKeystore(t *testing.T) {
+	caFile, certFile, keyFile := tlsFixture(t)
+	c, err := newFranzClientForTest(t, map[string]string{
+		"security.protocol":              "SSL",
+		"ssl.truststore.location":        caFile,
+		"ssl.truststore.type":            "PEM",
+		"ssl.keystore.type":              "PEM",
+		"ssl.keystore.certificate.chain": certFile,
+		"ssl.keystore.key":               keyFile,
+	})
+	require.NoError(t, err, "PEM-style keystore properties must be honored")
+	require.NotNil(t, c)
+	t.Cleanup(c.Close)
+}
+
+func TestNewFranzClient_SSL_LegacyKeystore(t *testing.T) {
+	caFile, certFile, keyFile := tlsFixture(t)
+	c, err := newFranzClientForTest(t, map[string]string{
+		"security.protocol":       "SSL",
+		"ssl.truststore.location": caFile,
+		"ssl.keystore.location":   certFile,
+		"ssl.key.location":        keyFile,
+	})
+	require.NoError(t, err, "legacy keystore properties must still work")
+	require.NotNil(t, c)
+	t.Cleanup(c.Close)
+}
+
+func TestNewFranzClient_SASL_SSL_Combined(t *testing.T) {
+	// SASL_SSL is a common production setup; make sure it also validates.
+	caFile, _, _ := tlsFixture(t)
+	c, err := newFranzClientForTest(t, map[string]string{
+		"security.protocol":       "SASL_SSL",
+		"ssl.truststore.location": caFile,
+		"sasl.mechanism":          "PLAIN",
+		"sasl.username":           "user",
+		"sasl.password":           "pass",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	t.Cleanup(c.Close)
+}
+
+func TestBuildTLSConfig_PEMKeystore(t *testing.T) {
+	caFile, certFile, keyFile := tlsFixture(t)
+	cfg, err := buildTLSConfig(map[string]string{
+		"ssl.truststore.location":        caFile,
+		"ssl.keystore.certificate.chain": certFile,
+		"ssl.keystore.key":               keyFile,
+	}, noopLogger())
+	require.NoError(t, err)
+	require.Len(t, cfg.Certificates, 1, "PEM keystore properties must load a client cert")
+	require.NotNil(t, cfg.RootCAs)
+}
+
+func TestBuildTLSConfig_PEMKeystore_PreferredOverLegacy(t *testing.T) {
+	// When both sets of keys are set, the PEM-style keys win. We detect that
+	// indirectly: point the legacy keys at a bogus path and the PEM keys at
+	// real files. A clean load proves the legacy path was not consulted.
+	_, certFile, keyFile := tlsFixture(t)
+	cfg, err := buildTLSConfig(map[string]string{
+		"ssl.keystore.certificate.chain": certFile,
+		"ssl.keystore.key":               keyFile,
+		"ssl.keystore.location":          "/nonexistent/bogus.pem",
+		"ssl.key.location":               "/nonexistent/bogus.key",
+	}, noopLogger())
+	require.NoError(t, err)
+	require.Len(t, cfg.Certificates, 1)
+}
+
+func TestBuildTLSConfig_AcceptsKeystoreTypePEM(t *testing.T) {
+	// ssl.keystore.type / ssl.truststore.type of "PEM" must be accepted
+	// without error (the exporter only supports PEM, so the value is
+	// informational).
+	cfg, err := buildTLSConfig(map[string]string{
+		"ssl.keystore.type":   "PEM",
+		"ssl.truststore.type": "PEM",
+	}, noopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
 }
 
 func TestClientMetrics_AllCounters(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes two bugs on the Kafka client's TLS path. Reported by @edgarkz on #33 — will close once they confirm on their cluster.

### 1. Dialer / DialTLSConfig collision (startup failure for every TLS cluster)

`internal/kafka/client.go` unconditionally appended `kgo.Dialer(...)` to the options slice and **additionally** appended `kgo.DialTLSConfig(...)` when `security.protocol` contained `SSL`. franz-go rejects that combination at `kgo.NewClient` time with:

```
cannot set both Dialer and DialTLSConfig
```

So any TLS-enabled cluster failed at startup. Replaced the custom `net.Dialer` with `kgo.DialTimeout(timeout)`, which sets the dial timeout without colliding with `DialTLSConfig`.

### 2. PEM keystore properties silently ignored (mTLS not working)

`buildTLSConfig` only consulted `ssl.keystore.location` + `ssl.key.location`. The PEM-style property names `ssl.keystore.certificate.chain` + `ssl.keystore.key` — which match Kafka's stock names when `ssl.keystore.type: PEM` and the original Scala `kafka-lag-exporter` — were silently dropped, so client-cert mTLS never worked for users following those docs. Now both name sets are accepted; if both are set simultaneously the PEM names win and a warning is logged. `ssl.keystore.type` / `ssl.truststore.type` of `PEM` are now accepted without error.

## Test coverage added

The SSL path had zero test coverage — that's how the collision shipped. Added to `internal/kafka/client_test.go`:

- `tlsFixture` helper that generates a self-signed cert + key into `t.TempDir()` using `crypto/x509` + `crypto/rsa` (2048-bit).
- `TestNewFranzClient_SSL_TruststoreOnly` — would have caught the Dialer/DialTLSConfig collision on its own.
- `TestNewFranzClient_SSL_PEMKeystore` — exercises the new PEM property names end-to-end.
- `TestNewFranzClient_SSL_LegacyKeystore` — pins legacy property names as still working.
- `TestNewFranzClient_SASL_SSL_Combined` — the common production setup.
- `TestBuildTLSConfig_PEMKeystore`, `TestBuildTLSConfig_PEMKeystore_PreferredOverLegacy`, `TestBuildTLSConfig_AcceptsKeystoreTypePEM` — unit-level coverage of the new `buildTLSConfig` branches.

Tests only invoke the constructor — they do not connect to a broker, since `kgo.NewClient` is lazy and the config validation that raises the collision error runs at construction time.

## Docs

- `README.md`: added a TLS / mTLS properties table under the Cluster Configuration section listing both the PEM and legacy property names.
- `charts/kafka-lag-exporter/values.yaml`: noted that `consumerProperties` and `adminClientProperties` are merged, so identical TLS config only needs to be declared once; expanded the commented example to show PEM keystore usage.

## Test plan

- [x] `make check` passes locally (gofmt, go vet, golangci-lint, `go test -race -count=1 ./internal/... ./cmd/...`)
- [x] New TLS tests fail on `master` with "cannot set both Dialer and DialTLSConfig" and pass on this branch
- [ ] Reporter (@edgarkz on #33) confirms startup succeeds against their TLS-enabled cluster with PEM-style keystore properties
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)