### PR TITLE
chore(release): prep 1.0.3 — Chart bump, CHANGELOG, GitHub Release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,3 +104,46 @@ jobs:
           helm push \
             "kafka-lag-exporter-${{ steps.version.outputs.version }}.tgz" \
             "oci://ghcr.io/${{ github.repository_owner }}/charts"
+
+  release:
+    name: Create GitHub Release
+    needs: helm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          cat > release-notes.md <<NOTES
+          ## Install
+
+          **Docker image**
+
+          \`\`\`bash
+          docker pull ghcr.io/${{ github.repository }}:${VERSION}
+          \`\`\`
+
+          **Helm chart (OCI)**
+
+          \`\`\`bash
+          helm install kafka-lag-exporter \\
+            oci://ghcr.io/${{ github.repository_owner }}/charts/kafka-lag-exporter \\
+            --version ${VERSION} \\
+            --namespace kafka-lag-exporter \\
+            --create-namespace
+          \`\`\`
+
+          ---
+          NOTES
+
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file release-notes.md \
+            --generate-notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-04-14
+
+### Fixed
+- Strimzi watcher now uses a namespace-scoped watch when `watchers.strimziWatchNamespace` is set, matching the chart's `Role`/`RoleBinding` scope. Previously the watcher always attempted a cluster-scoped watch, which was denied when only namespaced RBAC existed. ([#34](https://github.com/carlgra/kafka-lag-exporter/pull/34), reported in [#29](https://github.com/carlgra/kafka-lag-exporter/issues/29))
+- Strimzi autodiscovery now resolves bootstrap addresses for modern Strimzi v1beta2 clusters. Listener selection matches on the listener `name` field (`plain`/`tls`) and filters on `type` to only accept in-cluster listeners (`internal`), ignoring external exposures (`route`/`loadbalancer`/`nodeport`/`ingress`/`cluster-ip`). Prefers the `bootstrapServers` field over `addresses[0]`. Fallback service address uses `.svc.cluster.local` FQDN instead of the short form. ([#35](https://github.com/carlgra/kafka-lag-exporter/pull/35), reported in [#32](https://github.com/carlgra/kafka-lag-exporter/issues/32))
+- TLS-enabled Kafka clusters no longer fail at startup with "cannot set both Dialer and DialTLSConfig". The client now uses `kgo.DialTimeout` for connection timeouts, which composes with `kgo.DialTLSConfig`. ([#36](https://github.com/carlgra/kafka-lag-exporter/pull/36), reported in [#33](https://github.com/carlgra/kafka-lag-exporter/issues/33))
+
+### Added
+- PEM-style client-certificate keys for TLS (`ssl.keystore.certificate.chain` + `ssl.keystore.key`) are now honored by `buildTLSConfig`, matching the original Scala exporter's config surface. Previously only `ssl.keystore.location` + `ssl.key.location` were read, silently failing mTLS for users following the original docs. ([#36](https://github.com/carlgra/kafka-lag-exporter/pull/36))
+- GitHub Release automation: the release workflow now creates a GitHub Release with auto-generated notes after the chart publish completes.
+
+### Changed
+- `charts/kafka-lag-exporter/Chart.yaml` `version`/`appVersion` bumped to `1.0.3`. Previously drifted from releases (the workflow overrode values at package time but the source file was stale); now kept in sync.
+
+## [1.0.2] - 2026-04-13
+
+### Security
+- Removed Trivy vulnerability scanner from CI after the March 2026 Trivy supply chain compromise ([CVE-2026-33634](https://www.cvedetails.com/cve/CVE-2026-33634/), [CISA KEV](https://www.cisa.gov/news-events/alerts/2026/03/26/cisa-adds-one-known-exploited-vulnerability-catalog)). Replaced with `govulncheck` pinned to `v1.1.4` — official Go team tool distributed through the Go module proxy, call-graph aware (only flags CVEs actually reachable from application code). ([#31](https://github.com/carlgra/kafka-lag-exporter/pull/31))
+- Bumped Go toolchain from `1.25.7` → `1.25.9` in CI and Dockerfile to pick up stdlib fixes surfaced by `govulncheck`: [GO-2026-4601](https://pkg.go.dev/vuln/GO-2026-4601) (net/url IPv6 parsing), [GO-2026-4870](https://pkg.go.dev/vuln/GO-2026-4870) (crypto/tls KeyUpdate DoS), [GO-2026-4946](https://pkg.go.dev/vuln/GO-2026-4946) (crypto/x509 policy validation).
+
+### Added
+- Helm chart published as an OCI artifact on GHCR at `oci://ghcr.io/carlgra/charts/kafka-lag-exporter`. No `helm repo add` is required on Helm 3.8+:
+  ```bash
+  helm install kafka-lag-exporter \
+    oci://ghcr.io/carlgra/charts/kafka-lag-exporter \
+    --version <version>
+  ```
+  The release workflow packages and publishes the chart on every `v*` tag push, pinning chart `version`, `appVersion`, and default `image.tag` to the release tag for a consistent install experience. ([#30](https://github.com/carlgra/kafka-lag-exporter/pull/30))
+
+### Changed
+- Dockerfile base image pinned from `golang:1.25-alpine` → `golang:1.25.9-alpine` for reproducible stdlib versioning.
+
 ## [1.0.1] - 2026-03-09
 
 ### Fixed

--- a/charts/kafka-lag-exporter/Chart.yaml
+++ b/charts/kafka-lag-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-appVersion: "1.0.0"
+appVersion: "1.0.3"
 description: Kafka Lag Exporter (Go)
 name: kafka-lag-exporter
-version: 1.0.1
+version: 1.0.3
 maintainers:
 - name: Sean Glover


### PR DESCRIPTION
## Summary

Three small things ahead of cutting `v1.0.3`:

1. **`charts/kafka-lag-exporter/Chart.yaml`** — bump `version`/`appVersion` to `1.0.3`. The release workflow already overrides these at package time, but the source file had drifted (still said `1.0.1`/`1.0.0`). Cosmetic consistency.
2. **`CHANGELOG.md`** — retroactively documents `v1.0.2` (Trivy → govulncheck, Go 1.25.9 bump, OCI chart publishing), plus the three `v1.0.3` fixes (#34, #35, #36 — all from @edgarkz's reports).
3. **`.github/workflows/release.yml`** — new `release` job running after the helm publish. Uses `gh release create --generate-notes` with a small install-instructions preamble (docker pull + helm install commands). Auto-generated PR notes appear below.

## What happens after this merges

`git tag -a v1.0.3 -m "..." && git push origin v1.0.3` will:

1. Run the CI gate
2. Build + push the multi-arch Docker image to `ghcr.io/carlgra/kafka-lag-exporter:1.0.3`
3. Package + push the Helm chart to `oci://ghcr.io/carlgra/charts/kafka-lag-exporter:1.0.3`
4. **New:** create a GitHub Release at `/releases/tag/v1.0.3` with install instructions and auto-generated notes

No manual follow-up required.

## Test plan

- [x] `make check` passes (fmt, vet, lint, tests)
- [x] `helm lint charts/kafka-lag-exporter` passes with new versions
- [ ] After merge, cutting `v1.0.3` completes all four release steps green
- [ ] GitHub Release page at `/releases/tag/v1.0.3` renders with install commands + auto notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)