### PR TITLE
fix(helm): expose Prometheus maxTimeSeries in chart values

### DIFF
--- a/charts/kafka-lag-exporter/Chart.yaml
+++ b/charts/kafka-lag-exporter/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0.3"
 description: Kafka Lag Exporter (Go)
 name: kafka-lag-exporter
-version: 1.0.3
+version: 1.0.4
 maintainers:
 - name: Sean Glover

--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -115,6 +115,7 @@ data:
       prometheus:
         enabled: {{ .Values.sinks.prometheus.enabled }}
         port: {{ .Values.sinks.prometheus.port }}
+        maxTimeSeries: {{ .Values.sinks.prometheus.maxTimeSeries }}
       graphite:
         enabled: {{ .Values.sinks.graphite.enabled }}
         {{- if .Values.sinks.graphite.enabled }}

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -71,6 +71,9 @@ sinks:
     ## Bind address for the Prometheus HTTP server. Empty string binds to all interfaces.
     ## Set to "127.0.0.1" to restrict to localhost only.
     bindAddress: ""
+    ## Maximum number of time series to track. 0 means unlimited.
+    ## Set a positive value to cap cardinality (e.g. 200000).
+    maxTimeSeries: 0
   graphite:
     ## Flag to enable the graphite metrics reporter
     enabled: false


### PR DESCRIPTION
## Summary

- Fixes #38 -- the Helm chart's ConfigMap template was missing the `maxTimeSeries` field for the Prometheus sink, so users could not configure the cardinality limit via `values.yaml`
- Adds `sinks.prometheus.maxTimeSeries` to `values.yaml` (default `0` = unlimited, since the Go code treats `maxTimeSeries > 0` as the cap)
- Renders the value in `030-ConfigMap.yaml` alongside the existing `enabled` and `port` fields
- Bumps chart version to `1.0.4` (app version unchanged at `1.0.3` since no Go code changed)

## Test plan

- [x] `make check` passes (fmt, vet, lint, tests)
- [x] `helm lint charts/kafka-lag-exporter` passes
- [x] `helm template test charts/kafka-lag-exporter --set sinks.prometheus.maxTimeSeries=500000` renders `maxTimeSeries: 500000`
- [ ] Deploy to a cluster with high-cardinality workload and verify the warning is gone with `maxTimeSeries: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)