### PR TITLE
fix(prometheus): correct seriesCount tracking and report NaN for insufficient lookup data

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -424,7 +424,10 @@ func (c *Collector) computeMetrics(snapshot *OffsetsSnapshot) []metrics.MetricVa
 		})
 
 		// Compute time lag via lookup table.
-		var lagSeconds float64
+		// Default to NaN so that when the lookup has too few points (e.g. first
+		// poll cycle) we don't report a misleading zero. The sink's NaN filter
+		// will skip reporting this metric until a real value is available.
+		lagSeconds := math.NaN()
 		if table, ok := c.lookupTables[tp]; ok {
 			lookupResult := table.Lookup(groupOffset.Offset)
 			if lookupResult.Found {

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -759,6 +760,51 @@ func TestCollector_ReportClientMetrics_NoProvider(t *testing.T) {
 }
 
 // --- Negative lag clamping --------------------------------------------------
+
+// --- TooFewPoints / NaN lag seconds tests -----------------------------------
+
+func TestCollector_TooFewPoints_LagSecondsIsNaN(t *testing.T) {
+	// On the first poll cycle the lookup table has only one point, so Lookup
+	// returns Found=false (TooFewPoints). The collector should report NaN for
+	// lag_seconds so the Prometheus sink's NaN filter skips it.
+	tp := domain.TopicPartition{Topic: "t1", Partition: 0}
+	gtp := domain.GroupTopicPartition{
+		Group: "g1", Topic: "t1", Partition: 0,
+		MemberHost: "h1", ConsumerID: "c1", ClientID: "cl1",
+	}
+
+	mock := &mockClient{
+		groups: []string{"g1"},
+		gtps:   []domain.GroupTopicPartition{gtp},
+		groupOff: domain.GroupOffsets{
+			gtp: {Offset: 90, Timestamp: 1000},
+		},
+		earliestOff: domain.PartitionOffsets{tp: {Offset: 0, Timestamp: 1000}},
+		latestOff:   domain.PartitionOffsets{tp: {Offset: 100, Timestamp: 1000}},
+	}
+
+	rec := &recordingSink{}
+	c, err := NewCollector(
+		config.ClusterConfig{Name: "test"},
+		mock, []sink.Sink{rec},
+		func() lookup.LookupTable { return lookup.NewMemoryTable(60) },
+		10*time.Second, slog.Default(),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(200 * time.Millisecond); cancel() }()
+	c.Run(ctx)
+
+	// lag_seconds should be NaN (TooFewPoints on first cycle).
+	lagSec := rec.findMetric("kafka_consumergroup_group_lag_seconds")
+	require.NotNil(t, lagSec)
+	assert.True(t, math.IsNaN(lagSec.Value), "expected NaN for lag_seconds on first poll cycle, got %v", lagSec.Value)
+
+	// max_lag_seconds should NOT be reported when all partitions return NaN.
+	maxLagSec := rec.findMetric("kafka_consumergroup_group_max_lag_seconds")
+	assert.Nil(t, maxLagSec, "max_lag_seconds should not be reported when all partition lag_seconds are NaN")
+}
 
 func TestCollector_NegativeLagClampedToZero(t *testing.T) {
 	tp := domain.TopicPartition{Topic: "t1", Partition: 0}

--- a/internal/sink/prometheus.go
+++ b/internal/sink/prometheus.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -50,6 +51,8 @@ type PrometheusSink struct {
 	// Cardinality protection.
 	maxTimeSeries     int
 	seriesCount       atomic.Int64
+	knownSeries       map[string]struct{}
+	knownSeriesMu     sync.Mutex
 	droppedSeriesOnce sync.Once
 	droppedSeries     prometheus.Counter
 
@@ -143,6 +146,7 @@ func NewPrometheusSink(port int, bindAddress string, maxTimeSeries int, filter *
 		filter:            filter,
 		logger:            logger,
 		maxTimeSeries:     maxTimeSeries,
+		knownSeries:       make(map[string]struct{}),
 		pollsTotal:        pollsTotal,
 		pollErrors:        pollErrors,
 		pollDuration:      pollDuration,
@@ -242,23 +246,34 @@ func (s *PrometheusSink) Report(_ context.Context, m metrics.MetricValue) {
 		return
 	}
 
-	// Cardinality protection: skip new series if limit exceeded.
-	if s.maxTimeSeries > 0 && s.seriesCount.Load() >= int64(s.maxTimeSeries) {
-		s.droppedSeries.Inc()
-		s.droppedSeriesOnce.Do(func() {
-			s.logger.Warn("cardinality limit reached, dropping new series", "limit", s.maxTimeSeries)
-		})
-		return
-	}
-
 	labelValues := labelsToValues(m.Definition.Labels, m.Labels)
+
+	// Build a series key from metric name + label values to track unique time series.
+	seriesKey := m.Definition.Name + "\x00" + strings.Join(labelValues, "\x00")
+
+	s.knownSeriesMu.Lock()
+	_, known := s.knownSeries[seriesKey]
+	if !known {
+		// Cardinality protection: skip new series if limit exceeded.
+		if s.maxTimeSeries > 0 && s.seriesCount.Load() >= int64(s.maxTimeSeries) {
+			s.knownSeriesMu.Unlock()
+			s.droppedSeries.Inc()
+			s.droppedSeriesOnce.Do(func() {
+				s.logger.Warn("cardinality limit reached, dropping new series", "limit", s.maxTimeSeries)
+			})
+			return
+		}
+		s.knownSeries[seriesKey] = struct{}{}
+		s.seriesCount.Add(1)
+	}
+	s.knownSeriesMu.Unlock()
+
 	gauge, err := gv.GetMetricWithLabelValues(labelValues...)
 	if err != nil {
 		s.logger.Warn("failed to get metric", "metric", m.Definition.Name, "error", err)
 		return
 	}
 	gauge.Set(m.Value)
-	s.seriesCount.Add(1)
 }
 
 func (s *PrometheusSink) Remove(_ context.Context, m metrics.RemoveMetric) {
@@ -268,6 +283,24 @@ func (s *PrometheusSink) Remove(_ context.Context, m metrics.RemoveMetric) {
 	}
 	labelValues := labelsToValues(m.Definition.Labels, m.Labels)
 	gv.DeleteLabelValues(labelValues...)
+
+	// Remove from known series tracking so seriesCount stays accurate.
+	seriesKey := m.Definition.Name + "\x00" + strings.Join(labelValues, "\x00")
+	s.knownSeriesMu.Lock()
+	if _, known := s.knownSeries[seriesKey]; known {
+		delete(s.knownSeries, seriesKey)
+		s.seriesCount.Add(-1)
+	}
+	s.knownSeriesMu.Unlock()
+}
+
+// ResetSeriesCount clears the known series tracking. Call at the start of each
+// poll cycle so the count reflects only currently-active series.
+func (s *PrometheusSink) ResetSeriesCount() {
+	s.knownSeriesMu.Lock()
+	s.knownSeries = make(map[string]struct{})
+	s.seriesCount.Store(0)
+	s.knownSeriesMu.Unlock()
 }
 
 // labelsToValues converts a label map to an ordered slice matching the definition's label order.

--- a/internal/sink/prometheus_test.go
+++ b/internal/sink/prometheus_test.go
@@ -311,19 +311,26 @@ func TestPrometheusSink_ReportClientMetrics(t *testing.T) {
 func TestPrometheusSink_CardinalityLimit(t *testing.T) {
 	port := getFreePort()
 	filter, _ := NewMetricFilter([]string{".*"})
-	sink, err := NewPrometheusSink(port, "", 100000, filter, slog.Default())
+	sink, err := NewPrometheusSink(port, "", 5, filter, slog.Default())
 	require.NoError(t, err)
 	defer sink.Stop()
 	time.Sleep(100 * time.Millisecond)
 
-	// Set a low cardinality limit for testing.
-	sink.maxTimeSeries = 5
-	sink.seriesCount.Store(5) // Already at the limit.
-
 	ctx := context.Background()
+
+	// Fill up to the limit with 5 unique series.
+	for i := range 5 {
+		sink.Report(ctx, metrics.MetricValue{
+			Definition: metrics.PartitionLatestOffset,
+			Labels:     map[string]string{"cluster_name": "c", "topic": "t", "partition": fmt.Sprintf("%d", i)},
+			Value:      float64(i * 10),
+		})
+	}
+
+	// This 6th unique series should be dropped.
 	sink.Report(ctx, metrics.MetricValue{
 		Definition: metrics.PartitionLatestOffset,
-		Labels:     map[string]string{"cluster_name": "c", "topic": "t", "partition": "0"},
+		Labels:     map[string]string{"cluster_name": "c", "topic": "t", "partition": "99"},
 		Value:      100,
 	})
 
@@ -333,10 +340,129 @@ func TestPrometheusSink_CardinalityLimit(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 	bodyStr := string(body)
 
-	// The metric should have been dropped.
-	assert.False(t, strings.Contains(bodyStr, `kafka_partition_latest_offset{`))
+	// The 6th series should have been dropped.
+	assert.False(t, strings.Contains(bodyStr, `partition="99"`))
 	// The dropped counter should be incremented.
 	assert.Contains(t, bodyStr, "kafka_lag_exporter_dropped_series_total 1")
+}
+
+func TestPrometheusSink_SeriesCountTracksUniqueSeries(t *testing.T) {
+	port := getFreePort()
+	filter, _ := NewMetricFilter([]string{".*"})
+	sink, err := NewPrometheusSink(port, "", 0, filter, slog.Default())
+	require.NoError(t, err)
+	defer sink.Stop()
+
+	ctx := context.Background()
+
+	// Report 3 unique series for 100 cycles each.
+	for cycle := range 100 {
+		for i := range 3 {
+			sink.Report(ctx, metrics.MetricValue{
+				Definition: metrics.PartitionLatestOffset,
+				Labels:     map[string]string{"cluster_name": "c", "topic": "t", "partition": fmt.Sprintf("%d", i)},
+				Value:      float64(cycle*10 + i),
+			})
+		}
+	}
+
+	// seriesCount should be 3, not 300.
+	assert.Equal(t, int64(3), sink.seriesCount.Load())
+}
+
+func TestPrometheusSink_MaxTimeSeriesLimitsUniqueSeries(t *testing.T) {
+	port := getFreePort()
+	filter, _ := NewMetricFilter([]string{".*"})
+	sink, err := NewPrometheusSink(port, "", 3, filter, slog.Default())
+	require.NoError(t, err)
+	defer sink.Stop()
+	time.Sleep(100 * time.Millisecond)
+
+	ctx := context.Background()
+
+	// Report 3 unique series (fills the limit).
+	for i := range 3 {
+		sink.Report(ctx, metrics.MetricValue{
+			Definition: metrics.PartitionLatestOffset,
+			Labels:     map[string]string{"cluster_name": "c", "topic": "t", "partition": fmt.Sprintf("%d", i)},
+			Value:      float64(i),
+		})
+	}
+
+	// Updating existing series should still work.
+	sink.Report(ctx, metrics.MetricValue{
+		Definition: metrics.PartitionLatestOffset,
+		Labels:     map[string]string{"cluster_name": "c", "topic": "t", "partition": "0"},
+		Value:      999,
+	})
+
+	// New (4th) series should be dropped.
+	sink.Report(ctx, metrics.MetricValue{
+		Definition: metrics.PartitionLatestOffset,
+		Labels:     map[string]string{"cluster_name": "c", "topic": "t", "partition": "new"},
+		Value:      42,
+	})
+
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", port))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+
+	// Existing series updated.
+	assert.Contains(t, bodyStr, "999")
+	// New series dropped.
+	assert.False(t, strings.Contains(bodyStr, `partition="new"`))
+	// Series count is still 3.
+	assert.Equal(t, int64(3), sink.seriesCount.Load())
+}
+
+func TestPrometheusSink_ExistingSeriesContinueAfterLimit(t *testing.T) {
+	port := getFreePort()
+	filter, _ := NewMetricFilter([]string{".*"})
+	sink, err := NewPrometheusSink(port, "", 2, filter, slog.Default())
+	require.NoError(t, err)
+	defer sink.Stop()
+	time.Sleep(100 * time.Millisecond)
+
+	ctx := context.Background()
+
+	// Establish 2 series.
+	sink.Report(ctx, metrics.MetricValue{
+		Definition: metrics.PartitionLatestOffset,
+		Labels:     map[string]string{"cluster_name": "c", "topic": "t", "partition": "0"},
+		Value:      10,
+	})
+	sink.Report(ctx, metrics.MetricValue{
+		Definition: metrics.PartitionLatestOffset,
+		Labels:     map[string]string{"cluster_name": "c", "topic": "t", "partition": "1"},
+		Value:      20,
+	})
+
+	// Simulate many poll cycles updating the same 2 series.
+	for cycle := 1; cycle <= 50; cycle++ {
+		sink.Report(ctx, metrics.MetricValue{
+			Definition: metrics.PartitionLatestOffset,
+			Labels:     map[string]string{"cluster_name": "c", "topic": "t", "partition": "0"},
+			Value:      float64(10 + cycle),
+		})
+		sink.Report(ctx, metrics.MetricValue{
+			Definition: metrics.PartitionLatestOffset,
+			Labels:     map[string]string{"cluster_name": "c", "topic": "t", "partition": "1"},
+			Value:      float64(20 + cycle),
+		})
+	}
+
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", port))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+
+	// Both series should have the latest values (not frozen).
+	assert.Contains(t, bodyStr, "60") // 10 + 50
+	assert.Contains(t, bodyStr, "70") // 20 + 50
+	assert.Equal(t, int64(2), sink.seriesCount.Load())
 }
 
 func TestPrometheusSink_ReadyEndpoint_NoCheck(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Fix seriesCount leak (#38, #39):** `PrometheusSink.Report()` was incrementing `seriesCount` on every call, not just when a genuinely new time series was created. After `maxTimeSeries / N` poll cycles (where N = metrics per cycle), the cardinality limit was hit and ALL metric updates silently stopped, freezing every gauge at its last value. Fixed by tracking known series in a `map[string]struct{}` keyed by metric name + label values; `seriesCount` now reflects the number of unique time series, not total `Report()` invocations.
- **Fix misleading zero for lag_seconds (#38):** When the lookup table had too few points (e.g. first poll cycle, `TooFewPoints`), `lagSeconds` defaulted to `0` and was reported as a valid metric. Per the README, this should be NaN (not reported). Fixed by initializing `lagSeconds = math.NaN()` so the sink's existing NaN filter skips it until a real interpolated value is available.

Fixes #38, fixes #39

## Test plan

- [x] `make check` passes (gofmt, go vet, golangci-lint, all tests with -race)
- [x] New test: reporting same N metrics for 100 cycles results in seriesCount=N, not N*100
- [x] New test: maxTimeSeries limits unique series, not total updates; existing series continue updating after limit
- [x] New test: new series are blocked once limit is reached, but existing series keep updating
- [x] New test: when lookup returns TooFewPoints, lag_seconds is NaN and max_lag_seconds is not reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)