### PR TITLE
feat(strimzi): auto-configure TLS from Strimzi CR certificates for autodiscovered clusters

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,9 @@ type ClusterConfig struct {
 	Labels                map[string]string `mapstructure:"labels"`
 	ConsumerProperties    map[string]string `mapstructure:"consumerProperties"`
 	AdminClientProperties map[string]string `mapstructure:"adminClientProperties"`
+	// TLSCACert holds a PEM-encoded CA certificate for TLS connections.
+	// Set automatically by Strimzi autodiscovery from status.listeners[].certificates.
+	TLSCACert string `mapstructure:"tlsCACert"`
 }
 
 // WatcherConfig configures cluster watchers.

--- a/internal/kafka/client.go
+++ b/internal/kafka/client.go
@@ -67,6 +67,16 @@ func NewFranzClient(clusterCfg config.ClusterConfig, globalCfg *config.Config, l
 			if err != nil {
 				return nil, fmt.Errorf("building TLS config for cluster %s: %w", clusterCfg.Name, err)
 			}
+			// If no file-based CA was loaded but the cluster has an in-memory
+			// CA cert from Strimzi autodiscovery, use it as the trust anchor.
+			if tlsCfg.RootCAs == nil && clusterCfg.TLSCACert != "" {
+				pool := x509.NewCertPool()
+				if !pool.AppendCertsFromPEM([]byte(clusterCfg.TLSCACert)) {
+					return nil, fmt.Errorf("parsing in-memory CA certificate for cluster %s", clusterCfg.Name)
+				}
+				tlsCfg.RootCAs = pool
+				logger.Info("auto-TLS configured from Strimzi CR certificates", "cluster", clusterCfg.Name)
+			}
 			opts = append(opts, kgo.DialTLSConfig(tlsCfg))
 			logger.Info("TLS configured", "cluster", clusterCfg.Name)
 		}

--- a/internal/kafka/client_test.go
+++ b/internal/kafka/client_test.go
@@ -370,6 +370,75 @@ func TestBuildTLSConfig_AcceptsKeystoreTypePEM(t *testing.T) {
 	require.NotNil(t, cfg)
 }
 
+// --- TLSCACert (in-memory CA from Strimzi autodiscovery) tests ---------------
+
+// generateTestCACertPEM returns a PEM-encoded self-signed CA certificate
+// suitable for testing the in-memory CA cert path.
+func generateTestCACertPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(42),
+		Subject:               pkix.Name{CommonName: "test-strimzi-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes}))
+}
+
+func TestNewFranzClient_SSL_TLSCACert_InMemory(t *testing.T) {
+	caPEM := generateTestCACertPEM(t)
+	clusterCfg := config.ClusterConfig{
+		Name:               "strimzi-auto",
+		BootstrapBrokers:   "127.0.0.1:9093",
+		ConsumerProperties: map[string]string{"security.protocol": "SSL"},
+		TLSCACert:          caPEM,
+	}
+	globalCfg := &config.Config{KafkaClientTimeoutSeconds: 10}
+	c, err := NewFranzClient(clusterCfg, globalCfg, noopLogger())
+	require.NoError(t, err, "in-memory CA cert from Strimzi should work")
+	require.NotNil(t, c)
+	t.Cleanup(c.Close)
+}
+
+func TestNewFranzClient_SSL_TruststoreFileOverridesTLSCACert(t *testing.T) {
+	// When ssl.truststore.location is set (file-based), TLSCACert is ignored.
+	// This ensures static config takes precedence over autodiscovery.
+	caFile, _, _ := tlsFixture(t)
+	caPEM := generateTestCACertPEM(t) // different CA
+	clusterCfg := config.ClusterConfig{
+		Name:             "mixed",
+		BootstrapBrokers: "127.0.0.1:9093",
+		ConsumerProperties: map[string]string{
+			"security.protocol":       "SSL",
+			"ssl.truststore.location": caFile,
+		},
+		TLSCACert: caPEM,
+	}
+	globalCfg := &config.Config{KafkaClientTimeoutSeconds: 10}
+	c, err := NewFranzClient(clusterCfg, globalCfg, noopLogger())
+	require.NoError(t, err, "file-based truststore should take precedence")
+	require.NotNil(t, c)
+	t.Cleanup(c.Close)
+}
+
+func TestBuildTLSConfig_TLSCACert_NotUsedDirectly(t *testing.T) {
+	// buildTLSConfig itself doesn't handle TLSCACert — it only deals with
+	// properties. The in-memory cert is applied in NewFranzClient. Verify
+	// that buildTLSConfig with no truststore.location produces nil RootCAs.
+	cfg, err := buildTLSConfig(map[string]string{}, noopLogger())
+	require.NoError(t, err)
+	assert.Nil(t, cfg.RootCAs, "buildTLSConfig alone should not set RootCAs without truststore.location")
+}
+
 func TestClientMetrics_AllCounters(t *testing.T) {
 	m := &ClientMetrics{}
 	m.OnBrokerConnect(kgo.BrokerMetadata{}, 0, nil, nil)

--- a/internal/watcher/strimzi.go
+++ b/internal/watcher/strimzi.go
@@ -149,6 +149,9 @@ func (w *StrimziWatcher) handleEvent(ctx context.Context, event watch.Event) {
 	switch event.Type {
 	case watch.Added, watch.Modified:
 		w.logger.Info("cluster added/modified", "cluster", cluster.Name)
+		if cluster.TLSCACert != "" {
+			w.logger.Info("auto-TLS configured from Strimzi CR certificates", "cluster", cluster.Name)
+		}
 		ce = ClusterEvent{Type: ClusterAdded, Cluster: cluster}
 	case watch.Deleted:
 		w.logger.Info("cluster removed", "cluster", cluster.Name)
@@ -170,11 +173,12 @@ func extractClusterConfig(obj *unstructured.Unstructured) (config.ClusterConfig,
 
 	// Extract bootstrap server from status.
 	bootstrapServers := ""
+	var winningListener map[string]interface{}
 	status, found, _ := unstructured.NestedMap(obj.Object, "status")
 	if found {
 		listeners, found, _ := unstructured.NestedSlice(status, "listeners")
 		if found {
-			bootstrapServers = pickListenerBootstrap(listeners)
+			bootstrapServers, winningListener = pickListenerBootstrapAndMeta(listeners)
 		}
 	}
 
@@ -191,14 +195,42 @@ func extractClusterConfig(obj *unstructured.Unstructured) (config.ClusterConfig,
 	// Remove trailing comma if present.
 	bootstrapServers = strings.TrimRight(bootstrapServers, ",")
 
-	return config.ClusterConfig{
+	cluster := config.ClusterConfig{
 		Name:             clusterName,
 		BootstrapBrokers: bootstrapServers,
-	}, nil
+	}
+
+	// Auto-configure TLS from the winning listener's certificates or name.
+	if winningListener != nil {
+		caCert := extractListenerCACert(winningListener)
+		lname, _ := winningListener["name"].(string)
+		if caCert != "" || lname == "tls" {
+			cluster.TLSCACert = caCert
+			cluster.ConsumerProperties = map[string]string{"security.protocol": "SSL"}
+			cluster.AdminClientProperties = map[string]string{"security.protocol": "SSL"}
+		}
+	}
+
+	return cluster, nil
 }
 
-// pickListenerBootstrap selects the best in-cluster listener from the Strimzi
-// status.listeners slice and returns its bootstrap address.
+// extractListenerCACert extracts the first PEM certificate from a listener's
+// certificates field, if present.
+func extractListenerCACert(listener map[string]interface{}) string {
+	certs, ok := listener["certificates"].([]interface{})
+	if !ok || len(certs) == 0 {
+		return ""
+	}
+	cert, ok := certs[0].(string)
+	if !ok {
+		return ""
+	}
+	return cert
+}
+
+// pickListenerBootstrapAndMeta selects the best in-cluster listener from the
+// Strimzi status.listeners slice and returns its bootstrap address along with
+// the raw listener map for further inspection (e.g. certificates).
 //
 // In modern Strimzi v1beta2 the listener `name` field carries values like
 // "plain"/"tls" while `type` identifies the Kubernetes exposure mechanism
@@ -214,7 +246,7 @@ func extractClusterConfig(obj *unstructured.Unstructured) (config.ClusterConfig,
 // `addresses[0]`: the former is the authoritative Strimzi-advertised bootstrap
 // string, while the latter may contain a single address that is not suitable
 // for bootstrap connections.
-func pickListenerBootstrap(listeners []interface{}) string {
+func pickListenerBootstrapAndMeta(listeners []interface{}) (string, map[string]interface{}) {
 	// Priority: name=="plain", name=="tls", type=="plain" (legacy), type=="tls" (legacy).
 	type candidate struct {
 		priority int
@@ -258,20 +290,20 @@ func pickListenerBootstrap(listeners []interface{}) string {
 	}
 
 	if best.listener == nil {
-		return ""
+		return "", nil
 	}
 
 	if bs, ok := best.listener["bootstrapServers"].(string); ok && bs != "" {
-		return bs
+		return bs, best.listener
 	}
 	if addrs, ok := best.listener["addresses"].([]interface{}); ok && len(addrs) > 0 {
 		if addr, ok := addrs[0].(map[string]interface{}); ok {
 			host, _ := addr["host"].(string)
 			port, _ := addr["port"].(float64)
 			if host != "" && port > 0 {
-				return fmt.Sprintf("%s:%d", host, int(port))
+				return fmt.Sprintf("%s:%d", host, int(port)), best.listener
 			}
 		}
 	}
-	return ""
+	return "", nil
 }

--- a/internal/watcher/strimzi_test.go
+++ b/internal/watcher/strimzi_test.go
@@ -544,6 +544,128 @@ func TestStrimziWatcher_Watch_NamespaceScope(t *testing.T) {
 	assert.Equal(t, ns, observed(), "namespace-scope watch should pass configured namespace")
 }
 
+// --- auto-TLS from Strimzi CR certificates tests ----------------------------
+
+func TestExtractClusterConfig_TLSListenerWithCertificates(t *testing.T) {
+	certPEM := "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIUFakeTestCert=\n-----END CERTIFICATE-----\n"
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "secure-kafka",
+				"namespace": "backend",
+			},
+			"status": map[string]interface{}{
+				"listeners": []interface{}{
+					map[string]interface{}{
+						"name":             "tls",
+						"type":             "internal",
+						"bootstrapServers": "secure-kafka-bootstrap.backend.svc:9093",
+						"certificates": []interface{}{
+							certPEM,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cluster, err := extractClusterConfig(obj)
+	require.NoError(t, err)
+	assert.Equal(t, "backend/secure-kafka", cluster.Name)
+	assert.Equal(t, "secure-kafka-bootstrap.backend.svc:9093", cluster.BootstrapBrokers)
+	assert.Equal(t, certPEM, cluster.TLSCACert, "TLSCACert should be populated from listener certificates")
+	assert.Equal(t, "SSL", cluster.ConsumerProperties["security.protocol"], "security.protocol should be SSL")
+	assert.Equal(t, "SSL", cluster.AdminClientProperties["security.protocol"], "admin security.protocol should be SSL")
+}
+
+func TestExtractClusterConfig_TLSListenerWithoutCertificates(t *testing.T) {
+	// A TLS listener with name "tls" but no certificates field should still
+	// set security.protocol=SSL (the server may use a well-known CA).
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "secure-kafka",
+				"namespace": "ns",
+			},
+			"status": map[string]interface{}{
+				"listeners": []interface{}{
+					map[string]interface{}{
+						"name":             "tls",
+						"type":             "internal",
+						"bootstrapServers": "secure-kafka-bootstrap:9093",
+					},
+				},
+			},
+		},
+	}
+
+	cluster, err := extractClusterConfig(obj)
+	require.NoError(t, err)
+	assert.Empty(t, cluster.TLSCACert, "TLSCACert should be empty when no certificates present")
+	assert.Equal(t, "SSL", cluster.ConsumerProperties["security.protocol"], "TLS listener name should trigger SSL protocol")
+}
+
+func TestExtractClusterConfig_PlainListenerNoCertificates(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "kafka",
+				"namespace": "ns",
+			},
+			"status": map[string]interface{}{
+				"listeners": []interface{}{
+					map[string]interface{}{
+						"name":             "plain",
+						"type":             "internal",
+						"bootstrapServers": "kafka-bootstrap:9092",
+					},
+				},
+			},
+		},
+	}
+
+	cluster, err := extractClusterConfig(obj)
+	require.NoError(t, err)
+	assert.Empty(t, cluster.TLSCACert, "TLSCACert should be empty for plain listener")
+	assert.Empty(t, cluster.ConsumerProperties, "security.protocol should not be set for plain listener")
+	assert.Empty(t, cluster.AdminClientProperties, "admin security.protocol should not be set for plain listener")
+}
+
+func TestExtractClusterConfig_PlainPreferredOverTLSWithCerts(t *testing.T) {
+	// When both plain and tls listeners exist, plain wins by priority.
+	// TLS certificates from the tls listener should NOT be applied.
+	certPEM := "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIUFakeTestCert=\n-----END CERTIFICATE-----\n"
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "kafka",
+				"namespace": "ns",
+			},
+			"status": map[string]interface{}{
+				"listeners": []interface{}{
+					map[string]interface{}{
+						"name":             "tls",
+						"type":             "internal",
+						"bootstrapServers": "kafka-bootstrap:9093",
+						"certificates":     []interface{}{certPEM},
+					},
+					map[string]interface{}{
+						"name":             "plain",
+						"type":             "internal",
+						"bootstrapServers": "kafka-bootstrap:9092",
+					},
+				},
+			},
+		},
+	}
+
+	cluster, err := extractClusterConfig(obj)
+	require.NoError(t, err)
+	assert.Equal(t, "kafka-bootstrap:9092", cluster.BootstrapBrokers, "plain listener should win")
+	assert.Empty(t, cluster.TLSCACert, "no TLS since plain listener won")
+	assert.Empty(t, cluster.ConsumerProperties, "no security.protocol since plain listener won")
+}
+
 func TestStrimziWatcher_Stop(t *testing.T) {
 	w, _ := newFakeWatcher(t)
 	w.Stop()


### PR DESCRIPTION
## Summary

Fixes #32 — addresses the issue reported by @edgarkz where Strimzi autodiscovery picks the correct TLS bootstrap address but connects via plaintext, causing `"is this a plaintext connection speaking to a tls endpoint?"` errors.

- **Config layer** (`internal/config/config.go`): Added `TLSCACert` field to `ClusterConfig` to carry PEM-encoded CA certificates in memory
- **Watcher layer** (`internal/watcher/strimzi.go`): When the winning listener has a non-empty `certificates` field or is named `"tls"`, automatically sets `TLSCACert` and `security.protocol: SSL` on the cluster config
- **Client layer** (`internal/kafka/client.go`): When `TLSCACert` is set and no file-based truststore is configured, parses the in-memory PEM cert and uses it as the TLS root CA

Static cluster config with explicit TLS properties (e.g. `ssl.truststore.location`) still takes precedence over autodiscovered certificates — the in-memory CA is only used when no file-based CA is already loaded.

## Test plan

- [x] `make check` passes (fmt, vet, lint, test)
- [x] New test: TLS listener with certificates populates `TLSCACert` and sets `security.protocol=SSL`
- [x] New test: TLS listener without certificates still sets `security.protocol=SSL` (server may use well-known CA)
- [x] New test: Plain listener does NOT set TLS config
- [x] New test: Plain listener preferred over TLS listener — no TLS auto-config applied
- [x] New test: `NewFranzClient` with in-memory `TLSCACert` succeeds
- [x] New test: File-based truststore takes precedence over `TLSCACert`
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)